### PR TITLE
Add PCG64

### DIFF
--- a/pcgrandom/pcg_common.py
+++ b/pcgrandom/pcg_common.py
@@ -16,6 +16,14 @@ class PCGCommon(_random.Random):
     """
     Common base class for the PCG random generators.
     """
+    def __init__(self, seed=None, sequence=0):
+        self._state_mask = ~(-1 << self._state_bits)
+        sequence = _operator.index(sequence) & self._state_mask
+        self._increment = (
+            2 * sequence + self._base_increment
+            & self._state_mask
+        )
+        self.seed(seed)
 
     def seed(self, seed=None):
         """Initialize internal state from hashable object.

--- a/pcgrandom/pcg_common.py
+++ b/pcgrandom/pcg_common.py
@@ -1,0 +1,296 @@
+"""
+Common base class for the various PCG implementations.
+"""
+from __future__ import division
+
+import bisect as _bisect
+import collections as _collections
+import operator as _operator
+import os as _os
+import random as _random
+
+from builtins import int as _int, range as _range
+
+
+class PCGCommon(_random.Random):
+    """
+    Common base class for the PCG random generators.
+    """
+
+    def seed(self, seed=None):
+        """Initialize internal state from hashable object.
+        """
+        # XXX Compatibility note: unlike the base Random generator, we don't
+        # permit seeding from an arbitrary hashable object, since that makes it
+        # harder to guarantee reproducibility in the case that the hash
+        # changes.  See also http://bugs.python.org/issue27706.
+        if seed is None:
+            nbytes = self._state_bits // 8
+            seed = _int.from_bytes(_os.urandom(nbytes), byteorder='little')
+        else:
+            seed = _operator.index(seed)
+
+        self._set_state_from_seed(seed)
+        self.gauss_next = None
+
+    def getstate(self):
+        """Return internal state; can be passed to setstate() later."""
+        parameters = self._multiplier, self._increment
+        return self.VERSION, parameters, self._state, self.gauss_next
+
+    def setstate(self, state):
+        """Restore internal state from object returned by getstate()."""
+        version = state[0]
+        if version != self.VERSION:
+            raise ValueError(
+                "state with version {0!r} passed to "
+                "setstate() of version {1!r}".format(version, self.VERSION)
+            )
+
+        parameters, state, gauss_next = state[1:]
+        self.gauss_next = gauss_next
+        self._state = state
+        self._multiplier, self._increment = parameters
+
+    def getrandbits(self, k):
+        """Generate an integer in the range [0, 2**k).
+
+        Parameters
+        ----------
+        k : nonnegative integer
+
+        """
+        # XXX Compatibility note: k=0 is accepted.
+
+        k = _operator.index(k)
+        if k < 0:
+            raise ValueError("Number of bits should be nonnegative.")
+
+        output_bits = self._output_bits
+
+        numwords, excess_bits = -(-k // output_bits), -k % output_bits
+        acc = 0
+        for _ in _range(numwords):
+            acc = acc << output_bits | self._next_word()
+        return acc >> excess_bits
+
+    def random(self):
+        """Get the next random number in the range [0.0, 1.0)."""
+        return self.getrandbits(53)/9007199254740992
+
+    def _randbelow(self, n):
+        """Return a random integer in range(n)."""
+        output_bits = self._output_bits
+        # Invariant: x is uniformly distributed in range(h).
+        x, h = 0, 1
+        while True:
+            q, r = divmod(h, n)
+            if r <= x:
+                return (x - r) // q
+            x, h = x << output_bits | self._next_word(), r << output_bits
+
+    def randrange(self, start, stop=None, step=None):
+        """Choose a random item from range(start, stop[, step]).
+
+        """
+        # Reimplemented from the base class to ensure reproducibility
+        # across Python versions. The code below is adapted from that
+        # in Python 3.6.
+
+        # XXX Compatibility: randrange accepts numpy ints.
+        # XXX Compatibility: randrange does not accept floats;
+        #     an attempt to pass a float (integral or not) raises
+        #     TypeError. (For Random, it raises ValueError for non-integral
+        #     floats and is accepted for integral floats.) Similarly,
+        #     Decimal objects aren't supported.
+
+        istart = _operator.index(start)
+        if stop is None:
+            if istart > 0:
+                return self._randbelow(istart)
+            else:
+                raise ValueError(
+                    "empty range for randrange({0})".format(istart))
+
+        istop = _operator.index(stop)
+        width = istop - istart
+        if step is None:
+            if width > 0:
+                return istart + self._randbelow(width)
+            else:
+                raise ValueError(
+                    "empty range for randrange({0}, {1})".format(
+                        istart, istop))
+
+        istep = _operator.index(step)
+        if istep == 0:
+            raise ValueError("zero step for randrange()")
+        n = -(-width // istep)
+        if n > 0:
+            return istart + istep * self._randbelow(n)
+        else:
+            raise ValueError(
+                "empty range for randrange({0}, {1}, {2})".format(
+                    istart, istop, istep))
+
+    def _advance_state(self):
+        """Advance the underlying LCG a single step."""
+        self._state = (
+            self._state * self._multiplier + self._increment
+            & self._state_mask
+        )
+
+    def _next_word(self):
+        """Return next output; advance the underlying LCG.
+        """
+        output = self._get_output()
+        self._advance_state()
+        return output
+
+    def _set_state_from_seed(self, seed):
+        """Initialize generator from a given seed.
+
+        Parameters
+        ----------
+        seed : int
+            An integer seed to use to prime the generator.
+        """
+        seed &= self._state_mask
+
+        self._state = 0
+        self._next_word()
+        self._state = (self._state + seed) & self._state_mask
+        self._next_word()
+
+    def jumpahead(self, n):
+        """Jump ahead or back in the sequence of random numbers."""
+
+        a, c, m = self._multiplier, self._increment, self._state_mask
+
+        # Reduce n modulo the period of the sequence. Note that this
+        # turns negative jumps into positive ones.
+        n &= m
+
+        # Left-to-right binary powering algorithm.
+        an, cn = 1, 0
+        for bit in format(n, 'b'):
+            an, cn = an * an & m, an * cn + cn & m
+            if bit == '1':
+                an, cn = a * an & m, a * cn + c & m
+
+        self._state = self._state * an + cn & m
+
+    # sequence methods
+
+    def choice(self, seq):
+        """Choose a random element from a non-empty sequence."""
+        n = len(seq)
+        if n == 0:
+            raise IndexError("Cannot choose from an empty sequence")
+        return seq[self._randbelow(n)]
+
+    def shuffle(self, x):
+        """Shuffle list x in place, and return None."""
+        # XXX Compatibility note: shuffle does not support the
+        # second 'random' argument.
+
+        n = len(x)
+        for i in reversed(_range(n)):
+            j = i + self._randbelow(n - i)
+            if j > i:
+                x[i], x[j] = x[j], x[i]
+
+    def sample(self, population, k):
+        """Chooses k unique random elements from a population sequence or set.
+
+        Returns a new list containing elements from the population while
+        leaving the original population unchanged.  The resulting list is
+        in selection order so that all sub-slices will also be valid random
+        samples.  This allows raffle winners (the sample) to be partitioned
+        into grand prize and second place winners (the subslices).
+
+        Members of the population need not be hashable or unique.  If the
+        population contains repeats, then each occurrence is a possible
+        selection in the sample.
+
+        To choose a sample in a range of integers, use range as an argument.
+        This is especially fast and space efficient for sampling from a
+        large population:   sample(range(10000000), 60)
+        """
+        if isinstance(population, _collections.Set):
+            population = tuple(population)
+        if not isinstance(population, _collections.Sequence):
+            raise TypeError(
+                "Population must be a sequence or set.  "
+                "For dicts, use list(d).")
+
+        n = len(population)
+        if not 0 <= k <= n:
+            raise ValueError("Sample larger than population, or negative.")
+
+        # Algorithm based on one attributed to Robert Floyd, and appearing in
+        # "More Programming Pearls", by Jon Bentley.  See also the post to
+        # python-list dated May 28th 2010, entitled "A Friday Python
+        # Programming Pearl: random sampling".
+        d = {}
+        for i in reversed(_range(k)):
+            j = i + self._randbelow(n - i)
+            if j in d:
+                d[i] = d[j]
+            d[j] = i
+
+        result = [None] * k
+        for j, i in d.items():
+            result[i] = population[j]
+        return result
+
+    def choices(self, population, weights=None, cum_weights=None, k=1):
+        """Return k-sized list of population elements chosen with replacement.
+
+        If the relative weights or cumulative weights are not specified,
+        the selections are made with equal probability.
+
+        """
+        # XXX Compatibility note: cum_weights can be passed by position, but
+        # please don't. This is only for Python 2 support.
+        # XXX Compatibility note: if the sum of the weights is zero, a
+        # ValueError is raised rather than an IndexError.
+        # XXX Compatibility note: an IndexError is raised for an empty
+        # population, even if k=0.
+
+        # Code modified to remove the possibility of IndexError due to double
+        # rounding or subnormal weights. See http://bugs.python.org/issue24567
+
+        if cum_weights is None:
+            if weights is None:
+                if len(population) == 0:
+                    raise IndexError("Cannot choose from an empty population")
+                return [self.choice(population) for _ in _range(k)]
+            cum_weights, acc = [], 0
+            for weight in weights:
+                acc += weight
+                cum_weights.append(acc)
+        elif weights is not None:
+            raise TypeError(
+                "Cannot specify both weights and cumulative weights")
+
+        if len(population) == 0:
+            raise IndexError("Cannot choose from an empty population")
+        if len(cum_weights) != len(population):
+            raise ValueError(
+                "The number of weights does not match the population")
+        total = cum_weights[-1]
+        if total == 0:
+            raise ValueError(
+                "The total weight must be strictly positive.")
+        bisectors = [weight / total for weight in cum_weights]
+
+        # Note: a priori, the bisect call's return value could be
+        # len(population), which would cause an IndexError in the population
+        # lookup. However, that shouldn't happen: self.random() is strictly
+        # less than 1.0, and bisectors[-1] == 1.0, so the result of the bisect
+        # call should always be strictly smaller than len(population).
+        return [
+            population[_bisect.bisect(bisectors, self.random())]
+            for _ in range(k)
+        ]

--- a/pcgrandom/pcg_common.py
+++ b/pcgrandom/pcg_common.py
@@ -79,7 +79,7 @@ class PCGCommon(_random.Random):
         numwords, excess_bits = -(-k // output_bits), -k % output_bits
         acc = 0
         for _ in _range(numwords):
-            acc = acc << output_bits | self._next_word()
+            acc = acc << output_bits | self._next_output()
         return acc >> excess_bits
 
     def random(self):
@@ -95,7 +95,7 @@ class PCGCommon(_random.Random):
             q, r = divmod(h, n)
             if r <= x:
                 return (x - r) // q
-            x, h = x << output_bits | self._next_word(), r << output_bits
+            x, h = x << output_bits | self._next_output(), r << output_bits
 
     def randrange(self, start, stop=None, step=None):
         """Choose a random item from range(start, stop[, step]).
@@ -148,7 +148,7 @@ class PCGCommon(_random.Random):
             & self._state_mask
         )
 
-    def _next_word(self):
+    def _next_output(self):
         """Return next output; advance the underlying LCG.
         """
         output = self._get_output()
@@ -166,9 +166,9 @@ class PCGCommon(_random.Random):
         seed &= self._state_mask
 
         self._state = 0
-        self._next_word()
+        self._next_output()
         self._state = (self._state + seed) & self._state_mask
-        self._next_word()
+        self._next_output()
 
     def jumpahead(self, n):
         """Jump ahead or back in the sequence of random numbers."""

--- a/pcgrandom/pcg_xsh_rr_v0.py
+++ b/pcgrandom/pcg_xsh_rr_v0.py
@@ -11,6 +11,9 @@
 # XXX Fix use of __getstate__ and __reduce__.
 # XXX Style: make exceptions consistent (capital letter, full stop).
 # XXX Decide whether we really need the future dependency.
+# XXX Mark the version strings explicitly as Unicode, for Python 2 / Python 3
+#     compatibility.
+# XXX Rework reproducibility tests: JSON format for the results might work.
 
 from pcgrandom.pcg_common import PCGCommon as _PCGCommon
 

--- a/pcgrandom/pcg_xsh_rr_v0.py
+++ b/pcgrandom/pcg_xsh_rr_v0.py
@@ -14,13 +14,10 @@
 
 from __future__ import division
 
-import bisect as _bisect
-import collections as _collections
 import operator as _operator
-import os as _os
-import random as _random
 
-from builtins import int as _int, range as _range
+from pcgrandom.pcg_common import PCGCommon as _PCGCommon
+
 
 _UINT32_MASK = 2**32 - 1
 _UINT64_MASK = 2**64 - 1
@@ -55,7 +52,7 @@ def _rotate32(v, r):
     return (v >> r | v << (32-r)) & _UINT32_MASK
 
 
-class PCG_XSH_RR_V0(_random.Random):
+class PCG_XSH_RR_V0(_PCGCommon):
     """
     Random subclass based on Melissa O'Neill's PCG family.
 
@@ -64,6 +61,12 @@ class PCG_XSH_RR_V0(_random.Random):
     """
 
     VERSION = "pcgrandom.PCG_XSH_RR_V0"
+
+    _state_mask = _UINT64_MASK
+
+    _state_bits = 64
+
+    _output_bits = 32
 
     def __init__(self, seed=None, sequence=0):
         multiplier = _KNUTH_MMIX_LCG_MULTIPLIER
@@ -74,281 +77,10 @@ class PCG_XSH_RR_V0(_random.Random):
         self._increment = increment
         self.seed(seed)
 
-    def seed(self, seed=None):
-        """Initialize internal state from hashable object.
-        """
-        # XXX Compatibility note: unlike the base Random generator, we don't
-        # permit seeding from an arbitrary hashable object, since that makes it
-        # harder to guarantee reproducibility in the case that the hash
-        # changes.  See also http://bugs.python.org/issue27706.
-        if seed is None:
-            seed = _int.from_bytes(_os.urandom(8), byteorder='little')
-        else:
-            seed = _operator.index(seed)
-
-        self._set_state_from_seed(seed)
-        self.gauss_next = None
-
-    def random(self):
-        """Get the next random number in the range [0.0, 1.0)."""
-
-        # Same generation method as in the Mersenne Twister code. Constants in
-        # the final line are 2**26 and 2**53.
-        a = self._next_word() >> 5
-        b = self._next_word() >> 6
-        return (a*67108864.0+b)/9007199254740992.0
-
-    def getstate(self):
-        """Return internal state; can be passed to setstate() later."""
-        parameters = self._multiplier, self._increment
-        return self.VERSION, parameters, self._state, self.gauss_next
-
-    def setstate(self, state):
-        """Restore internal state from object returned by getstate()."""
-        version = state[0]
-        if version != self.VERSION:
-            raise ValueError(
-                "state with version {0!r} passed to "
-                "setstate() of version {1!r}".format(version, self.VERSION)
-            )
-
-        parameters, state, gauss_next = state[1:]
-        self.gauss_next = gauss_next
-        self._state = state
-        self._multiplier, self._increment = parameters
-
-    def getrandbits(self, k):
-        """Generate an integer in the range [0, 2**k).
-
-        Parameters
-        ----------
-        k : nonnegative integer
-
-        """
-        # XXX Compatibility note: k=0 is accepted.
-
-        k = _operator.index(k)
-        if k < 0:
-            raise ValueError("Number of bits should be nonnegative.")
-
-        # k = 32 * numwords - excess_bits, 0 <= excess_bits < 32
-        numwords, excess_bits = -(-k // 32), -k % 32
-        acc = 0
-        for _ in _range(numwords):
-            acc = acc << 32 | self._next_word()
-        return acc >> excess_bits
-
-    def jumpahead(self, n):
-        """Jump ahead or back in the sequence of random numbers."""
-
-        # Reduce n modulo the period of the sequence.
-        n = _operator.index(n)
-        n &= _UINT64_MASK
-        a, c = self._multiplier, self._increment
-
-        # Left-to-right powering algorithm.
-        an, cn = 1, 0
-        for bit in format(n, 'b'):
-            an, cn = an * an & _UINT64_MASK, an * cn + cn & _UINT64_MASK
-            if bit == '1':
-                an, cn = a * an & _UINT64_MASK, a * cn + c & _UINT64_MASK
-
-        self._state = (self._state * an + cn) & _UINT64_MASK
-
-    def randrange(self, start, stop=None, step=None):
-        """Choose a random item from range(start, stop[, step]).
-
-        """
-        # Reimplemented from the base class to ensure reproducibility
-        # across Python versions. The code below is adapted from that
-        # in Python 3.6.
-
-        # XXX Compatibility: randrange accepts numpy ints.
-        # XXX Compatibility: randrange does not accept floats;
-        #     an attempt to pass a float (integral or not) raises
-        #     TypeError. (For Random, it raises ValueError for non-integral
-        #     floats and is accepted for integral floats.) Similarly,
-        #     Decimal objects aren't supported.
-
-        istart = _operator.index(start)
-        if stop is None:
-            if istart > 0:
-                return self._randbelow(istart)
-            else:
-                raise ValueError(
-                    "empty range for randrange({0})".format(istart))
-
-        istop = _operator.index(stop)
-        width = istop - istart
-        if step is None:
-            if width > 0:
-                return istart + self._randbelow(width)
-            else:
-                raise ValueError(
-                    "empty range for randrange({0}, {1})".format(
-                        istart, istop))
-
-        istep = _operator.index(step)
-        if istep == 0:
-            raise ValueError("zero step for randrange()")
-        n = -(-width // istep)
-        if n > 0:
-            return istart + istep * self._randbelow(n)
-        else:
-            raise ValueError(
-                "empty range for randrange({0}, {1}, {2})".format(
-                    istart, istop, istep))
-
-    def _randbelow(self, n):
-        """Return a random integer in range(n)."""
-        # Invariant: x is uniformly distributed in range(h).
-        x, h = 0, 1
-        while True:
-            q, r = divmod(h, n)
-            if r <= x:
-                return (x - r) // q
-            x, h = x << 32 | self._next_word(), r << 32
-
-    # sequence methods
-
-    def choice(self, seq):
-        """Choose a random element from a non-empty sequence."""
-        n = len(seq)
-        if n == 0:
-            raise IndexError("Cannot choose from an empty sequence")
-        return seq[self._randbelow(n)]
-
-    def shuffle(self, x):
-        """Shuffle list x in place, and return None."""
-        # XXX Compatibility note: shuffle does not support the
-        # second 'random' argument.
-
-        n = len(x)
-        for i in reversed(_range(n)):
-            j = i + self._randbelow(n - i)
-            if j > i:
-                x[i], x[j] = x[j], x[i]
-
-    def sample(self, population, k):
-        """Chooses k unique random elements from a population sequence or set.
-
-        Returns a new list containing elements from the population while
-        leaving the original population unchanged.  The resulting list is
-        in selection order so that all sub-slices will also be valid random
-        samples.  This allows raffle winners (the sample) to be partitioned
-        into grand prize and second place winners (the subslices).
-
-        Members of the population need not be hashable or unique.  If the
-        population contains repeats, then each occurrence is a possible
-        selection in the sample.
-
-        To choose a sample in a range of integers, use range as an argument.
-        This is especially fast and space efficient for sampling from a
-        large population:   sample(range(10000000), 60)
-        """
-        if isinstance(population, _collections.Set):
-            population = tuple(population)
-        if not isinstance(population, _collections.Sequence):
-            raise TypeError(
-                "Population must be a sequence or set.  "
-                "For dicts, use list(d).")
-
-        n = len(population)
-        if not 0 <= k <= n:
-            raise ValueError("Sample larger than population, or negative.")
-
-        # Algorithm based on one attributed to Robert Floyd, and appearing in
-        # "More Programming Pearls", by Jon Bentley.  See also the post to
-        # python-list dated May 28th 2010, entitled "A Friday Python
-        # Programming Pearl: random sampling".
-        d = {}
-        for i in reversed(_range(k)):
-            j = i + self._randbelow(n - i)
-            if j in d:
-                d[i] = d[j]
-            d[j] = i
-
-        result = [None] * k
-        for j, i in d.items():
-            result[i] = population[j]
-        return result
-
-    def choices(self, population, weights=None, cum_weights=None, k=1):
-        """Return k-sized list of population elements chosen with replacement.
-
-        If the relative weights or cumulative weights are not specified,
-        the selections are made with equal probability.
-
-        """
-        # XXX Compatibility note: cum_weights can be passed by position, but
-        # please don't. This is only for Python 2 support.
-        # XXX Compatibility note: if the sum of the weights is zero, a
-        # ValueError is raised rather than an IndexError.
-        # XXX Compatibility note: an IndexError is raised for an empty
-        # population, even if k=0.
-
-        # Code modified to remove the possibility of IndexError due to double
-        # rounding or subnormal weights. See http://bugs.python.org/issue24567
-
-        if cum_weights is None:
-            if weights is None:
-                if len(population) == 0:
-                    raise IndexError("Cannot choose from an empty population")
-                return [self.choice(population) for _ in _range(k)]
-            cum_weights, acc = [], 0
-            for weight in weights:
-                acc += weight
-                cum_weights.append(acc)
-        elif weights is not None:
-            raise TypeError(
-                "Cannot specify both weights and cumulative weights")
-
-        if len(population) == 0:
-            raise IndexError("Cannot choose from an empty population")
-        if len(cum_weights) != len(population):
-            raise ValueError(
-                "The number of weights does not match the population")
-        total = cum_weights[-1]
-        if total == 0:
-            raise ValueError(
-                "The total weight must be strictly positive.")
-        bisectors = [weight / total for weight in cum_weights]
-
-        # Note: a priori, the bisect call's return value could be
-        # len(population), which would cause an IndexError in the population
-        # lookup. However, that shouldn't happen: self.random() is strictly
-        # less than 1.0, and bisectors[-1] == 1.0, so the result of the bisect
-        # call should always be strictly smaller than len(population).
-        return [
-            population[_bisect.bisect(bisectors, self.random())]
-            for _ in range(k)
-        ]
-
     # Private helper functions.
 
-    def _set_state_from_seed(self, seed):
-        """Initialize generator from a given seed.
-
-        Parameters
-        ----------
-        seed : int
-            An integer seed to use to prime the generator.
-        """
-        seed &= _UINT64_MASK
-
-        self._state = 0
-        self._next_word()
-        self._state = (self._state + seed) & _UINT64_MASK
-        self._next_word()
-
-    def _next_word(self):
-        """Return next output; advance the underlying LCG.
-        """
+    def _get_output(self):
+        """Compute output from current state."""
         state = self._state
         output_word = ((state ^ (state >> 18)) >> 27) & _UINT32_MASK
-        output_shift = state >> 59
-        output = _rotate32(output_word, output_shift)
-        new_state = state * self._multiplier + self._increment
-        new_state &= _UINT64_MASK
-        self._state = new_state
-        return output
+        return _rotate32(output_word, state >> 59)

--- a/pcgrandom/pcg_xsh_rr_v0.py
+++ b/pcgrandom/pcg_xsh_rr_v0.py
@@ -12,21 +12,10 @@
 # XXX Style: make exceptions consistent (capital letter, full stop).
 # XXX Decide whether we really need the future dependency.
 
-from __future__ import division
-
-import operator as _operator
-
 from pcgrandom.pcg_common import PCGCommon as _PCGCommon
 
 
 _UINT32_MASK = 2**32 - 1
-_UINT64_MASK = 2**64 - 1
-
-# Constants reportedly used by Knuth for MMIX's LCG.  These values are given on
-# the Wikipedia page for Linear Congruential Generators, and can be found in
-# various other references online, but I was unable to find the primary source.
-_KNUTH_MMIX_LCG_MULTIPLIER = 6364136223846793005
-_KNUTH_MMIX_LCG_INCREMENT = 1442695040888963407
 
 
 def _rotate32(v, r):
@@ -62,22 +51,15 @@ class PCG_XSH_RR_V0(_PCGCommon):
 
     VERSION = "pcgrandom.PCG_XSH_RR_V0"
 
-    _state_mask = _UINT64_MASK
-
     _state_bits = 64
 
     _output_bits = 32
 
-    def __init__(self, seed=None, sequence=0):
-        multiplier = _KNUTH_MMIX_LCG_MULTIPLIER
-        sequence = _operator.index(sequence) & _UINT64_MASK
-        increment = (2 * sequence + _KNUTH_MMIX_LCG_INCREMENT) & _UINT64_MASK
+    # Multiplier reportedly used by Knuth for the MMIX LCG.
+    _multiplier = 6364136223846793005
 
-        self._multiplier = multiplier
-        self._increment = increment
-        self.seed(seed)
-
-    # Private helper functions.
+    # Increment reportedly used by Knuth for the MMIX LCG.
+    _base_increment = 1442695040888963407
 
     def _get_output(self):
         """Compute output from current state."""

--- a/pcgrandom/pcg_xsl_rr_v0.py
+++ b/pcgrandom/pcg_xsl_rr_v0.py
@@ -1,12 +1,7 @@
-from __future__ import division
-
-import operator as _operator
-
 from pcgrandom.pcg_common import PCGCommon as _PCGCommon
 
 
 _UINT64_MASK = 2**64 - 1
-_UINT128_MASK = 2**128 - 1
 
 # Constant from Table 4 of "Tables of linear congruential generators of
 # different sizes and good lattice stucture", Pierre L'Ecuyer, Mathematics of
@@ -49,22 +44,13 @@ class PCG_XSL_RR_V0(_PCGCommon):
 
     VERSION = "pcgrandom.PCG_XSL_RR_V0"
 
-    _state_mask = _UINT128_MASK
-
     _state_bits = 128
 
     _output_bits = 64
 
-    def __init__(self, seed=None, sequence=0):
-        multiplier = _LECUYER_MULTIPLIER
-        sequence = _operator.index(sequence) & _UINT128_MASK
-        increment = (2 * sequence + _128BIT_INCREMENT) & _UINT128_MASK
+    _multiplier = _LECUYER_MULTIPLIER
 
-        self._multiplier = multiplier
-        self._increment = increment
-        self.seed(seed)
-
-    # Private helper functions.
+    _base_increment = _128BIT_INCREMENT
 
     def _get_output(self):
         """Compute output from current state."""

--- a/pcgrandom/pcg_xsl_rr_v0.py
+++ b/pcgrandom/pcg_xsl_rr_v0.py
@@ -1,0 +1,73 @@
+from __future__ import division
+
+import operator as _operator
+
+from pcgrandom.pcg_common import PCGCommon as _PCGCommon
+
+
+_UINT64_MASK = 2**64 - 1
+_UINT128_MASK = 2**128 - 1
+
+# Constant from Table 4 of "Tables of linear congruential generators of
+# different sizes and good lattice stucture", Pierre L'Ecuyer, Mathematics of
+# Computation vol. 68, no. 225, January 1999, pp 249-260. The increment is
+# chosen randomly.
+_LECUYER_MULTIPLIER = 47026247687942121848144207491837523525
+_128BIT_INCREMENT = 209568312854995847869081903677183368518
+
+
+def _rotate64(v, r):
+    """
+    An unsigned 64-bit bitwise "clockwise" rotation of r bits on v.
+
+    If v has more than 64 bits, only the least significant 64 bits
+    are used.
+
+    Parameters
+    ----------
+    v : integer in range 0 <= v < 2**64
+        The value to rotate.
+    r : integer in the range 0 <= r < 64
+        The number of bits to rotate by.
+
+    Returns
+    -------
+    integer in range 0 <= v < 2**64
+        Result of shifting v right by r places, rotating the
+        bits that drop off back into the high end of v.
+    """
+    return (v >> r | v << (64-r)) & _UINT64_MASK
+
+
+class PCG_XSL_RR_V0(_PCGCommon):
+    """
+    Random subclass based on Melissa O'Neill's PCG family.
+
+    This implements the generator described in section 6.3.3 of the PCG paper,
+    PCG-XSL-RR, sitting on a 128-bit LCG with multiplier from L'Ecuyer.
+    """
+
+    VERSION = "pcgrandom.PCG_XSL_RR_V0"
+
+    _state_mask = _UINT128_MASK
+
+    _state_bits = 128
+
+    _output_bits = 64
+
+    def __init__(self, seed=None, sequence=0):
+        multiplier = _LECUYER_MULTIPLIER
+        sequence = _operator.index(sequence) & _UINT128_MASK
+        increment = (2 * sequence + _128BIT_INCREMENT) & _UINT128_MASK
+
+        self._multiplier = multiplier
+        self._increment = increment
+        self.seed(seed)
+
+    # Private helper functions.
+
+    def _get_output(self):
+        """Compute output from current state."""
+        state = self._state
+        output_word = (state ^ (state >> 64)) & _UINT64_MASK
+        return _rotate64(output_word, state >> 122)

--- a/pcgrandom/test/test_common.py
+++ b/pcgrandom/test/test_common.py
@@ -1,0 +1,311 @@
+"""
+Tests common to all generators.
+"""
+
+import collections
+import itertools
+import math
+
+# 99% values of the chi-squared statistic used in the goodness-of-fit tests
+# below, indexed by degrees of freedom. Values calculated using
+# scipy.stats.chi2(dof).ppf(0.99)
+chisq_99percentile = {
+    3: 11.344866730144371,
+    4: 13.276704135987622,
+    12: 26.21696730553585,
+    23: 41.63839811885848,
+    31: 52.19139483319192,
+}
+
+
+class TestCommon(object):
+    def test_getrandbits(self):
+        k = 5
+        samples = [self.gen.getrandbits(k) for _ in range(10000)]
+        self.check_uniform(range(2**k), samples)
+
+    def test_getrandbits_large(self):
+        k = 101
+        nsamples = 10000
+        samples = [self.gen.getrandbits(k) for _ in range(nsamples)]
+
+        # Count number of times individual bits have appeared.
+        counts = {}
+        for bitpos in range(k):
+            bit = 2**bitpos
+            counts[bitpos] = sum(1 for sample in samples if (sample & bit))
+
+        # Assuming that each bit is "fair", each count roughly follows a normal
+        # distribution with mean 0.5*nsamples and standard deviation
+        # 0.5*sqrt(nsamples). We'll call a count bad if it's more than 3
+        # standard deviations from the mean.
+
+        bad_counts = 0
+        for count in counts.values():
+            if abs(counts[0] - 0.5*nsamples) > 1.5*math.sqrt(nsamples):
+                bad_counts += 1
+
+        # There's about a 1 in 370 chance of any one count being bad,
+        # and the counts should be independent. To be safe, we allow
+        # up to three bad counts before failing.
+        self.assertLessEqual(bad_counts, 3)
+
+    def test_getrandbits_zero_bits(self):
+        # getrandbits(0) is a valid operation (unlike the random.Random
+        # version), but since it doesn't need any randomness it shouldn't
+        # advance the state.
+        state = self.gen.getstate()
+        for _ in range(10):
+            result = self.gen.getrandbits(0)
+            self.assertEqual(result, 0)
+        self.assertEqual(self.gen.getstate(), state)
+
+    def test_getrandbits_negative_bits(self):
+        with self.assertRaises(ValueError):
+            self.gen.getrandbits(-1)
+
+    def test_randrange_uniform(self):
+        n = 13
+        samples = [self.gen.randrange(n) for _ in range(10000)]
+        self.check_uniform(range(n), samples)
+
+    def test_randrange_one_doesnt_advance_state(self):
+        # randrange(1) should work, but doesn't need any random
+        # input, so shouldn't end up advancing the state.
+        state_before = self.gen.getstate()
+
+        samples = [self.gen.randrange(1) for _ in range(10)]
+        self.assertEqual(samples, [0]*10)
+
+        state_after = self.gen.getstate()
+        self.assertEqual(state_before, state_after)
+
+    def test_randrange_float_arguments(self):
+        with self.assertRaises(TypeError):
+            self.gen.randrange(5.0)
+        with self.assertRaises(TypeError):
+            self.gen.randrange(2.0, 7)
+        with self.assertRaises(TypeError):
+            self.gen.randrange(2, 7.0)
+        with self.assertRaises(TypeError):
+            self.gen.randrange(2, 7, 1.0)
+        with self.assertRaises(TypeError):
+            self.gen.randrange(2, 7, 2.0)
+
+    def test_randrange_start_only(self):
+        # See http://bugs.python.org/issue9379 for related discussion.
+        samples = [self.gen.randrange(23) for _ in range(1000)]
+        # Chance of getting only 22 of the possible 23 outcomes is < 1.2e-18.
+        self.assertEqual(set(samples), set(range(23)))
+
+        with self.assertRaises(ValueError):
+            self.gen.randrange(0)
+        with self.assertRaises(ValueError):
+            self.gen.randrange(-5)
+
+    def test_randrange_start_and_stop(self):
+        samples = [self.gen.randrange(-10, 13) for _ in range(1000)]
+        self.assertEqual(set(samples), set(range(-10, 13)))
+
+        with self.assertRaises(ValueError):
+            self.gen.randrange(20, 20)
+        with self.assertRaises(ValueError):
+            self.gen.randrange(21, 20)
+
+    def test_randrange_start_stop_and_step(self):
+        test_ranges = [
+            (16, 37, 5),
+            (5, 35, 5),
+            (4, 35, 5),
+            (35, 5, -5),
+            (36, 5, -5),
+        ]
+
+        for test_range in test_ranges:
+            samples = [self.gen.randrange(*test_range) for _ in range(1000)]
+            self.assertEqual(set(samples), set(range(*test_range)))
+
+        with self.assertRaises(ValueError):
+            self.gen.randrange(0, 20, 0)
+        with self.assertRaises(ValueError):
+            self.gen.randrange(0, -20, 0)
+        with self.assertRaises(ValueError):
+            self.gen.randrange(0, 5, -1)
+        with self.assertRaises(ValueError):
+            self.gen.randrange(0, -5, 1)
+        with self.assertRaises(ValueError):
+            self.gen.randrange(22, 22, -1)
+        with self.assertRaises(ValueError):
+            self.gen.randrange(47, 47, 1)
+
+    def test_choice(self):
+        with self.assertRaises(IndexError):
+            self.gen.choice([])
+
+        nsamples = 1000
+        seq = "ABCD"
+        choices = [
+            self.gen.choice(seq) for _ in range(nsamples)
+        ]
+        self.check_uniform(seq, choices)
+
+    def test_sample(self):
+        samples = [tuple(self.gen.sample(range(4), 3)) for _ in range(10000)]
+        population = list(itertools.permutations(range(4), 3))
+        self.check_uniform(population, samples)
+
+    def test_sample_set(self):
+        s = set('ABCDEFG')
+        sample = self.gen.sample(s, 3)
+        self.assertLess(set(sample), s)
+
+    def test_sample_dict(self):
+        d = dict(a=1, b=2, c=3)
+        with self.assertRaises(TypeError):
+            self.gen.sample(d, 2)
+
+    def test_sample_corner_cases(self):
+        self.assertEqual(self.gen.sample([], 0), [])
+        with self.assertRaises(ValueError):
+            self.assertEqual(self.gen.sample([], 1))
+        with self.assertRaises(ValueError):
+            self.assertEqual(self.gen.sample([], -1))
+
+    def test_shuffle(self):
+        population = list(range(13))
+
+        result = self.gen.shuffle(population)
+        self.assertIsNone(result)
+        self.assertNotEqual(population, list(range(13)))
+        self.assertEqual(set(population), set(range(13)))
+
+        population = list(range(4))
+
+        samples = []
+        for _ in range(10000):
+            self.gen.shuffle(population)
+            samples.append(tuple(population))
+
+        self.check_uniform(
+            list(itertools.permutations(range(4))),
+            samples,
+        )
+
+    def test_shuffle_corner_cases(self):
+        # shuffling a length 0 or 1 sequence shouldn't be a problem
+        population = []
+        self.gen.shuffle(population)
+        self.assertEqual(population, [])
+
+        population = [13]
+        self.gen.shuffle(population)
+        self.assertEqual(population, [13])
+
+    def test_choices(self):
+        population = list(range(5))
+
+        sample = self.gen.choices(population, k=10000)
+        self.check_uniform(population, sample)
+
+        weights = [2, 3, 0, 1, 4]
+        sample = self.gen.choices(population, weights=weights, k=10000)
+        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
+
+        cum_weights = [2, 5, 5, 6, 10]
+        sample = self.gen.choices(population, cum_weights=cum_weights, k=10000)
+        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
+
+    def test_choices_subnormal_weights(self):
+        # Corner case where random.Random triggers an IndexError.
+        population = list(range(5))
+        weights = [1e-323, 0.0, 2e-323, 2e-323, 1e-323]
+        sample = self.gen.choices(population, weights=weights, k=10000)
+        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
+
+        population = list(range(6))
+        weights = [1e-323, 0.0, 2e-323, 2e-323, 1e-323, 0.0]
+        sample = self.gen.choices(population, weights=weights, k=10000)
+        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
+
+    def test_choices_error_conditions(self):
+        # Can't specify both weights and cum_weights.
+        with self.assertRaises(TypeError):
+            self.gen.choices(
+                range(3), weights=[1, 2, 3], cum_weights=[1, 3, 6])
+
+        # Two errors here: empty population, and both weights and cum_weights
+        # specified. The TypeError for the bad signature should win.
+        with self.assertRaises(TypeError):
+            self.gen.choices([], weights=[1, 2, 3], cum_weights=[1, 3, 6])
+
+        # Empty population: IndexError to match random.choice. We should get an
+        # exception even in the corner case that zero samples are requested.
+        with self.assertRaises(IndexError):
+            self.gen.choices([], weights=[])
+        with self.assertRaises(IndexError):
+            self.gen.choices([], cum_weights=[])
+        with self.assertRaises(IndexError):
+            self.gen.choices([])
+        with self.assertRaises(IndexError):
+            self.gen.choices([], weights=[], k=0)
+        with self.assertRaises(IndexError):
+            self.gen.choices([], cum_weights=[], k=0)
+        with self.assertRaises(IndexError):
+            self.gen.choices([], k=0)
+
+        # Number of weights doesn't match population.
+        with self.assertRaises(ValueError):
+            self.gen.choices(range(3), weights=[1, 2])
+        with self.assertRaises(ValueError):
+            self.gen.choices(range(3), cum_weights=[1, 2])
+
+        # Total weight is zero.
+        with self.assertRaises(ValueError):
+            self.gen.choices(range(3), weights=[0.0, 0.0, 0.0])
+        with self.assertRaises(ValueError):
+            self.gen.choices(range(3), cum_weights=[0.0, 0.0, 0.0])
+
+    def check_uniform(self, population, sample):
+        """
+        Check uniformity via a chi-squared test with p-value 0.99.
+
+        Requires that there's an entry for len(population) - 1
+        in the chisq_99percentile dictionary.
+
+        Parameters
+        ----------
+        population : sequence
+            The population that the samples are drawn from.
+        sample : sequence
+            The generated sample.
+        """
+        weights = {i: 1 for i in population}
+        self.check_goodness_of_fit(weights, sample)
+
+    def check_goodness_of_fit(self, weights, sample):
+        """
+        Perform a chi-squared goodness of fit test.
+
+        Requires that there's an entry for len(expected) - 1
+        in the chisq_99percentile dictionary.
+
+        sample : the sample to be tested
+        weights : mapping from members of the population to their
+            expected weights. The weights need not be normalised.
+        """
+        counts = collections.Counter(sample)
+        # Expected frequencies for this sample.
+        total = sum(weights.values())
+        expected = {
+            i: w / total * len(sample) for i, w in weights.items() if w}
+
+        # Check that we don't have any extraneous objects in our sample.  This
+        # also acts as a check that elements with zero weight haven't been
+        # generated.
+        self.assertLessEqual(set(counts), set(expected))
+
+        stat = sum(
+            (counts[i] - expected[i])**2 / expected[i]
+            for i in expected
+        )
+        self.assertLess(stat, chisq_99percentile[len(expected)-1])

--- a/pcgrandom/test/test_common.py
+++ b/pcgrandom/test/test_common.py
@@ -182,7 +182,7 @@ class TestCommon(object):
 
         bad_counts = 0
         for count in counts.values():
-            if abs(counts[0] - 0.5*nsamples) > 1.5*math.sqrt(nsamples):
+            if abs(count - 0.5*nsamples) > 1.5*math.sqrt(nsamples):
                 bad_counts += 1
 
         # There's about a 1 in 370 chance of any one count being bad,

--- a/pcgrandom/test/test_pcg_xsh_rr_v0.py
+++ b/pcgrandom/test/test_pcg_xsh_rr_v0.py
@@ -3,13 +3,12 @@ Tests for the PCG_XSH_RR_V0 generator.
 """
 from __future__ import division
 
-import collections
 import contextlib
-import itertools
 import math
 import unittest
 
 from pcgrandom.pcg_xsh_rr_v0 import PCG_XSH_RR_V0
+from pcgrandom.test.test_common import TestCommon
 
 
 # Sequences used for detecting reproducibility regressions.
@@ -41,18 +40,6 @@ seq0_seed12345_shuffle = [
 ]
 
 
-# 99% values of the chi-squared statistic used in various
-# tests below, indexed by degrees of freedom. Values
-# calculated using scipy.stats.chi2(dof).ppf(0.99)
-chisq_99percentile = {
-    3: 11.344866730144371,
-    4: 13.276704135987622,
-    12: 26.21696730553585,
-    23: 41.63839811885848,
-    31: 52.19139483319192,
-}
-
-
 @contextlib.contextmanager
 def count_samples_generated(gen):
     """
@@ -74,7 +61,10 @@ def count_samples_generated(gen):
         del gen._next_word
 
 
-class Test_PCG_XSH_RR_V0(unittest.TestCase):
+class Test_PCG_XSH_RR_V0(TestCommon, unittest.TestCase):
+    def setUp(self):
+        self.gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+
     def test_creation_without_seed(self):
         gen1 = PCG_XSH_RR_V0()
         gen2 = PCG_XSH_RR_V0()
@@ -224,54 +214,6 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         samples2 = [gen.gauss(0.0, 1.0) for _ in range(5)]
         self.assertEqual(samples1, samples2)
 
-    def test_getrandbits(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        k = 5
-        samples = [gen.getrandbits(k) for _ in range(10000)]
-        self.check_uniform(range(2**k), samples)
-
-    def test_getrandbits_large(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        k = 379
-        samples = [gen.getrandbits(k) for _ in range(1000)]
-
-        self.assertGreaterEqual(min(samples), 0)
-        self.assertLess(max(samples), 2**379)
-        # It's possible, but vanishingly unlikely, that all values
-        # are less than 2**378.
-        self.assertGreaterEqual(max(samples), 2**378)
-
-    def test_getrandbits_zero_bits(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-        result = gen.getrandbits(0)
-        self.assertEqual(result, 0)
-
-    def test_getrandbits_negative_bits(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-        with self.assertRaises(ValueError):
-            gen.getrandbits(-1)
-
-    def test_randrange_uniform(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        # Indirect test of our _randbelow override.
-        n = 13
-        samples = [gen.randrange(n) for _ in range(10000)]
-        self.check_uniform(range(n), samples)
-
-    def test_randrange_one(self):
-        # Corner case.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-        state_before = gen.getstate()
-
-        samples = [gen.randrange(1) for _ in range(10)]
-        self.assertEqual(samples, [0]*10)
-
-        state_after = gen.getstate()
-        self.assertEqual(state_before, state_after)
-
     def test_randrange_of_wordsize(self):
         # Using randrange(2**32) should consume exactly one
         # sample each time.
@@ -312,213 +254,6 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
             self.assertEqual(sample, samples[next_pos])
             current_pos = next_pos + 1
 
-    def test_randrange_float_arguments(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        with self.assertRaises(TypeError):
-            gen.randrange(5.0)
-        with self.assertRaises(TypeError):
-            gen.randrange(2.0, 7)
-        with self.assertRaises(TypeError):
-            gen.randrange(2, 7.0)
-        with self.assertRaises(TypeError):
-            gen.randrange(2, 7, 1.0)
-        with self.assertRaises(TypeError):
-            gen.randrange(2, 7, 2.0)
-
-    def test_randrange_start_only(self):
-        # See http://bugs.python.org/issue9379 for related discussion.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-        samples = [gen.randrange(23) for _ in range(1000)]
-        # Chance of getting only 22 of the possible 23 outcomes is < 1.2e-18.
-        self.assertEqual(set(samples), set(range(23)))
-
-        with self.assertRaises(ValueError):
-            gen.randrange(0)
-        with self.assertRaises(ValueError):
-            gen.randrange(-5)
-
-    def test_randrange_start_and_stop(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-        samples = [gen.randrange(-10, 13) for _ in range(1000)]
-        self.assertEqual(set(samples), set(range(-10, 13)))
-
-        with self.assertRaises(ValueError):
-            gen.randrange(20, 20)
-        with self.assertRaises(ValueError):
-            gen.randrange(21, 20)
-
-    def test_randrange_start_stop_and_step(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        test_ranges = [
-            (16, 37, 5),
-            (5, 35, 5),
-            (4, 35, 5),
-            (35, 5, -5),
-            (36, 5, -5),
-        ]
-
-        for test_range in test_ranges:
-            samples = [gen.randrange(*test_range) for _ in range(1000)]
-            self.assertEqual(set(samples), set(range(*test_range)))
-
-        with self.assertRaises(ValueError):
-            gen.randrange(0, 20, 0)
-        with self.assertRaises(ValueError):
-            gen.randrange(0, -20, 0)
-        with self.assertRaises(ValueError):
-            gen.randrange(0, 5, -1)
-        with self.assertRaises(ValueError):
-            gen.randrange(0, -5, 1)
-        with self.assertRaises(ValueError):
-            gen.randrange(22, 22, -1)
-        with self.assertRaises(ValueError):
-            gen.randrange(47, 47, 1)
-
-    def test_choice(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        with self.assertRaises(IndexError):
-            gen.choice([])
-
-        nsamples = 1000
-        seq = "ABCD"
-        choices = [
-            gen.choice(seq) for _ in range(nsamples)
-        ]
-        self.check_uniform(seq, choices)
-
-    def test_sample(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        samples = [tuple(gen.sample(range(4), 3)) for _ in range(10000)]
-        population = list(itertools.permutations(range(4), 3))
-        self.check_uniform(population, samples)
-
-    def test_sample_set(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        s = set('ABCDEFG')
-        sample = gen.sample(s, 3)
-        self.assertLess(set(sample), s)
-
-    def test_sample_dict(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        d = dict(a=1, b=2, c=3)
-        with self.assertRaises(TypeError):
-            gen.sample(d, 2)
-
-    def test_sample_corner_cases(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-        self.assertEqual(gen.sample([], 0), [])
-        with self.assertRaises(ValueError):
-            self.assertEqual(gen.sample([], 1))
-        with self.assertRaises(ValueError):
-            self.assertEqual(gen.sample([], -1))
-
-    def test_shuffle(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-        population = list(range(13))
-
-        result = gen.shuffle(population)
-        self.assertIsNone(result)
-        self.assertNotEqual(population, list(range(13)))
-        self.assertEqual(set(population), set(range(13)))
-
-        population = list(range(4))
-
-        samples = []
-        for _ in range(10000):
-            gen.shuffle(population)
-            samples.append(tuple(population))
-
-        self.check_uniform(
-            list(itertools.permutations(range(4))),
-            samples,
-        )
-
-    def test_shuffle_corner_cases(self):
-        # shuffling a length 0 or 1 sequence shouldn't be a problem
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-        population = []
-        gen.shuffle(population)
-        self.assertEqual(population, [])
-
-        population = [13]
-        gen.shuffle(population)
-        self.assertEqual(population, [13])
-
-    def test_choices(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        population = list(range(5))
-
-        sample = gen.choices(population, k=10000)
-        self.check_uniform(population, sample)
-
-        weights = [2, 3, 0, 1, 4]
-        sample = gen.choices(population, weights=weights, k=10000)
-        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
-
-        cum_weights = [2, 5, 5, 6, 10]
-        sample = gen.choices(population, cum_weights=cum_weights, k=10000)
-        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
-
-    def test_choices_subnormal_weights(self):
-        # Corner case where random.Random triggers an IndexError.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        population = list(range(5))
-        weights = [1e-323, 0.0, 2e-323, 2e-323, 1e-323]
-        sample = gen.choices(population, weights=weights, k=10000)
-        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
-
-        population = list(range(6))
-        weights = [1e-323, 0.0, 2e-323, 2e-323, 1e-323, 0.0]
-        sample = gen.choices(population, weights=weights, k=10000)
-        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
-
-    def test_choices_error_conditions(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        # Can't specify both weights and cum_weights.
-        with self.assertRaises(TypeError):
-            gen.choices(range(3), weights=[1, 2, 3], cum_weights=[1, 3, 6])
-
-        # Two errors here: empty population, and both weights and cum_weights
-        # specified. The TypeError for the bad signature should win.
-        with self.assertRaises(TypeError):
-            gen.choices([], weights=[1, 2, 3], cum_weights=[1, 3, 6])
-
-        # Empty population: IndexError to match random.choice. We should get an
-        # exception even in the corner case that zero samples are requested.
-        with self.assertRaises(IndexError):
-            gen.choices([], weights=[])
-        with self.assertRaises(IndexError):
-            gen.choices([], cum_weights=[])
-        with self.assertRaises(IndexError):
-            gen.choices([])
-        with self.assertRaises(IndexError):
-            gen.choices([], weights=[], k=0)
-        with self.assertRaises(IndexError):
-            gen.choices([], cum_weights=[], k=0)
-        with self.assertRaises(IndexError):
-            gen.choices([], k=0)
-
-        # Number of weights doesn't match population.
-        with self.assertRaises(ValueError):
-            gen.choices(range(3), weights=[1, 2])
-        with self.assertRaises(ValueError):
-            gen.choices(range(3), cum_weights=[1, 2])
-
-        # Total weight is zero.
-        with self.assertRaises(ValueError):
-            gen.choices(range(3), weights=[0.0, 0.0, 0.0])
-        with self.assertRaises(ValueError):
-            gen.choices(range(3), cum_weights=[0.0, 0.0, 0.0])
-
     def test_count_samples_generated(self):
         # This is really a test for our count_samples_generated helper
         # rather than for the PRNG.
@@ -533,48 +268,3 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
 
         [gen.randrange(27) for _ in range(13)]
         self.assertEqual(wordgen.call_count, 41)
-
-    def check_uniform(self, population, sample):
-        """
-        Check uniformity via a chi-squared test with p-value 0.99.
-
-        Requires that there's an entry for len(population) - 1
-        in the chisq_99percentile dictionary.
-
-        Parameters
-        ----------
-        population : sequence
-            The population that the samples are drawn from.
-        sample : sequence
-            The generated sample.
-        """
-        weights = {i: 1 for i in population}
-        self.check_goodness_of_fit(weights, sample)
-
-    def check_goodness_of_fit(self, weights, sample):
-        """
-        Perform a chi-squared goodness of fit test.
-
-        Requires that there's an entry for len(expected) - 1
-        in the chisq_99percentile dictionary.
-
-        sample : the sample to be tested
-        weights : mapping from members of the population to their
-            expected weights. The weights need not be normalised.
-        """
-        counts = collections.Counter(sample)
-        # Expected frequencies for this sample.
-        total = sum(weights.values())
-        expected = {
-            i: w / total * len(sample) for i, w in weights.items() if w}
-
-        # Check that we don't have any extraneous objects in our sample.  This
-        # also acts as a check that elements with zero weight haven't been
-        # generated.
-        self.assertLessEqual(set(counts), set(expected))
-
-        stat = sum(
-            (counts[i] - expected[i])**2 / expected[i]
-            for i in expected
-        )
-        self.assertLess(stat, chisq_99percentile[len(expected)-1])

--- a/pcgrandom/test/test_pcg_xsh_rr_v0.py
+++ b/pcgrandom/test/test_pcg_xsh_rr_v0.py
@@ -3,7 +3,6 @@ Tests for the PCG_XSH_RR_V0 generator.
 """
 from __future__ import division
 
-import math
 import unittest
 
 from pcgrandom.pcg_xsh_rr_v0 import PCG_XSH_RR_V0
@@ -40,19 +39,10 @@ seq0_seed12345_shuffle = [
 
 
 class Test_PCG_XSH_RR_V0(TestCommon, unittest.TestCase):
+    gen_class = PCG_XSH_RR_V0
+
     def setUp(self):
-        self.gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-    def test_creation_without_seed(self):
-        gen1 = PCG_XSH_RR_V0()
-        gen2 = PCG_XSH_RR_V0()
-
-        sample1 = [gen1.random() for _ in range(10)]
-        sample2 = [gen2.random() for _ in range(10)]
-
-        # Possible in theory for these two samples to be identical; vanishingly
-        # unlikely in practice.
-        self.assertNotEqual(sample1, sample2)
+        self.gen = self.gen_class(seed=15206, sequence=1729)
 
     def test_reproducibility(self):
         gen = PCG_XSH_RR_V0(seed=12345, sequence=0)
@@ -86,62 +76,3 @@ class Test_PCG_XSH_RR_V0(TestCommon, unittest.TestCase):
         population = list(range(20))
         gen.shuffle(population)
         self.assertEqual(population, seq0_seed12345_shuffle)
-
-    def test_sequence_default(self):
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345)
-        self.assertEqual(gen1.getstate(), gen2.getstate())
-
-    def test_independent_sequences(self):
-        # Crude statistical test for lack of correlation. If X and Y are
-        # independent and uniform on [0, 1], then (X - 0.5) * (Y - 0.5) has
-        # mean 0 and standard deviation 1/12. By the central limit theorem, we
-        # expect the average V of N such independent values to be roughly
-        # normally distributed with mean 0 and standard deviation 1 /
-        # (12*sqrt(N)). So we expect |V| to be at most 1 / (4*sqrt(N)) with
-        # over 99% probability.
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345, sequence=1)
-        N = 10000
-        xs = [gen1.random() for _ in range(N)]
-        ys = [gen2.random() for _ in range(N)]
-        v = sum((x - 0.5) * (y - 0.5) for x, y in zip(xs, ys)) / N
-        # Check we're within 3 standard deviations of the mean.
-        self.assertLess(abs(v), 0.25/math.sqrt(N))
-
-    def test_no_shared_state(self):
-        # Get samples first from gen1, then from gen2.
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345, sequence=1)
-        sample1_1 = [gen1.random() for _ in range(10)]
-        sample2_1 = [gen2.random() for _ in range(10)]
-
-        # Now in the opposite order: from gen2, then from gen1.
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345, sequence=1)
-        sample2_2 = [gen2.random() for _ in range(10)]
-        sample1_2 = [gen1.random() for _ in range(10)]
-
-        # Now interleaved.
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345, sequence=1)
-        sample1_3 = []
-        sample2_3 = []
-        for _ in range(10):
-            sample1_3.append(gen1.random())
-            sample2_3.append(gen2.random())
-
-        # Results should be the same in all cases.
-        self.assertEqual(sample1_1, sample1_2)
-        self.assertEqual(sample1_1, sample1_3)
-        self.assertEqual(sample2_1, sample2_2)
-        self.assertEqual(sample2_1, sample2_3)
-
-    def test_restore_state_from_different_generator(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=27)
-        state = gen.getstate()
-
-        bad_version = 'pcgrandom.PCG_XSH_RR_V1'
-        bad_state = (bad_version,) + state[1:]
-        with self.assertRaises(ValueError):
-            gen.setstate(bad_state)

--- a/pcgrandom/test/test_pcg_xsh_rr_v0.py
+++ b/pcgrandom/test/test_pcg_xsh_rr_v0.py
@@ -3,7 +3,6 @@ Tests for the PCG_XSH_RR_V0 generator.
 """
 from __future__ import division
 
-import contextlib
 import math
 import unittest
 
@@ -40,27 +39,6 @@ seq0_seed12345_shuffle = [
 ]
 
 
-@contextlib.contextmanager
-def count_samples_generated(gen):
-    """
-    Keep track of number of samples produced by the given generator.
-    """
-    word_generator = gen._next_word
-
-    def replacement_word_generator():
-        replacement_word_generator.call_count += 1
-        return word_generator()
-
-    replacement_word_generator.call_count = 0
-
-    # Shadow the class method with a local definition.
-    gen._next_word = replacement_word_generator
-    try:
-        yield replacement_word_generator
-    finally:
-        del gen._next_word
-
-
 class Test_PCG_XSH_RR_V0(TestCommon, unittest.TestCase):
     def setUp(self):
         self.gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
@@ -75,20 +53,6 @@ class Test_PCG_XSH_RR_V0(TestCommon, unittest.TestCase):
         # Possible in theory for these two samples to be identical; vanishingly
         # unlikely in practice.
         self.assertNotEqual(sample1, sample2)
-
-    def test_seed_resets_gauss_state(self):
-        gen = PCG_XSH_RR_V0()
-
-        gen.seed(2143)
-        x1 = gen.random()
-        y1 = gen.gauss(0.0, 1.0)
-
-        gen.seed(2143)
-        x2 = gen.random()
-        y2 = gen.gauss(0.0, 1.0)
-
-        self.assertEqual(x1, x2)
-        self.assertEqual(y1, y2)
 
     def test_reproducibility(self):
         gen = PCG_XSH_RR_V0(seed=12345, sequence=0)
@@ -173,21 +137,6 @@ class Test_PCG_XSH_RR_V0(TestCommon, unittest.TestCase):
         self.assertEqual(sample2_1, sample2_2)
         self.assertEqual(sample2_1, sample2_3)
 
-    def test_save_and_restore_state(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=27)
-
-        # Generate some values.
-        [gen.random() for _ in range(10)]
-
-        # Save the state, generate some more.
-        state = gen.getstate()
-        samples2 = [gen.random() for _ in range(10)]
-
-        # Restore the state, check we get the same samples.
-        gen.setstate(state)
-        samples3 = [gen.random() for _ in range(10)]
-        self.assertEqual(samples2, samples3)
-
     def test_restore_state_from_different_generator(self):
         gen = PCG_XSH_RR_V0(seed=15206, sequence=27)
         state = gen.getstate()
@@ -196,75 +145,3 @@ class Test_PCG_XSH_RR_V0(TestCommon, unittest.TestCase):
         bad_state = (bad_version,) + state[1:]
         with self.assertRaises(ValueError):
             gen.setstate(bad_state)
-
-    def test_state_preserves_gauss(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=27)
-
-        # Test a state with gauss_next = None
-        state = gen.getstate()
-        samples1 = [gen.gauss(0.0, 1.0) for _ in range(5)]
-        gen.setstate(state)
-        samples2 = [gen.gauss(0.0, 1.0) for _ in range(5)]
-        self.assertEqual(samples1, samples2)
-
-        # ... and a state with gauss_next non-None.
-        state = gen.getstate()
-        samples1 = [gen.gauss(0.0, 1.0) for _ in range(5)]
-        gen.setstate(state)
-        samples2 = [gen.gauss(0.0, 1.0) for _ in range(5)]
-        self.assertEqual(samples1, samples2)
-
-    def test_randrange_of_wordsize(self):
-        # Using randrange(2**32) should consume exactly one
-        # sample each time.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        with count_samples_generated(gen) as wordgen:
-            for index in range(10000):
-                self.assertEqual(wordgen.call_count, index)
-                gen.randrange(2**32)
-                self.assertEqual(wordgen.call_count, index+1)
-
-    def test_jumpahead(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-        # Generate samples, each sample consuming exactly one word
-        # from the core generator.
-        samples = [gen.randrange(2**32) for _ in range(1000)]
-
-        # Rewind, check we can produce the exact same samples.
-        gen.jumpahead(-1000)
-        same_again = [gen.randrange(2**32) for _ in range(1000)]
-        self.assertEqual(samples, same_again)
-
-        # Corner case: jumpahead(0) should work.
-        state_before = gen.getstate()
-        gen.jumpahead(0)
-        state_after = gen.getstate()
-        self.assertEqual(state_before, state_after)
-
-        # Now jump around randomly within the collection of samples. Use a
-        # separate generator for the positions to jump to.
-        posgen = PCG_XSH_RR_V0(seed=19733, sequence=22)
-
-        current_pos = 1000
-        for _ in range(100):
-            next_pos = posgen.randrange(1000)
-            gen.jumpahead(next_pos - current_pos)
-            sample = gen.randrange(2**32)
-            self.assertEqual(sample, samples[next_pos])
-            current_pos = next_pos + 1
-
-    def test_count_samples_generated(self):
-        # This is really a test for our count_samples_generated helper
-        # rather than for the PRNG.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
-
-        [gen.randrange(13) for _ in range(14)]
-        with count_samples_generated(gen) as wordgen:
-            [gen.randrange(27) for _ in range(21)]
-            self.assertEqual(wordgen.call_count, 21)
-            [gen.random() for _ in range(10)]
-            self.assertEqual(wordgen.call_count, 41)
-
-        [gen.randrange(27) for _ in range(13)]
-        self.assertEqual(wordgen.call_count, 41)

--- a/pcgrandom/test/test_pcg_xsl_rr_v0.py
+++ b/pcgrandom/test/test_pcg_xsl_rr_v0.py
@@ -1,5 +1,5 @@
 """
-Tests for the PCG_XSH_RR_V0 generator.
+Tests for the PCG_XSL_RR_V0 generator.
 """
 from __future__ import division
 
@@ -9,35 +9,35 @@ import itertools
 import math
 import unittest
 
-from pcgrandom.pcg_xsh_rr_v0 import PCG_XSH_RR_V0
+from pcgrandom.pcg_xsl_rr_v0 import PCG_XSL_RR_V0
 
 
 # Sequences used for detecting reproducibility regressions.
 seq0_seed12345_die_rolls = [
-    2, 5, 5, 4, 1, 6, 4, 4, 2, 5, 2, 6, 6, 2, 3, 1, 2, 6, 2, 6]
+    1, 2, 4, 4, 1, 4, 2, 2, 6, 1, 6, 2, 4, 6, 6, 5, 1, 1, 2, 6]
 seq0_seed12345_uniforms = [
-    float.fromhex('0x1.5086103ef2a40p-2'),
-    float.fromhex('0x1.90a33cef220a7p-1'),
-    float.fromhex('0x1.2be0bbe709ca8p-3'),
-    float.fromhex('0x1.21bded2b2a972p-1'),
-    float.fromhex('0x1.0a20e3b6ce7f8p-2'),
-    float.fromhex('0x1.5307c0cf5db08p-2'),
-    float.fromhex('0x1.cdd6de4c7c725p-1'),
-    float.fromhex('0x1.65d8359c989eap-2'),
-    float.fromhex('0x1.ea43f297b8b18p-3'),
-    float.fromhex('0x1.0be283eba30c0p-2'),
+    float.fromhex('0x1.36feb111851b8p-3'),
+    float.fromhex('0x1.d0eab4d2dacd0p-3'),
+    float.fromhex('0x1.3153584d8fc39p-1'),
+    float.fromhex('0x1.2839f1285a962p-1'),
+    float.fromhex('0x1.dd8596e786ab0p-5'),
+    float.fromhex('0x1.295b84d5041f7p-1'),
+    float.fromhex('0x1.86227587a6c34p-3'),
+    float.fromhex('0x1.5ac08820e8fc8p-3'),
+    float.fromhex('0x1.bbdbd5409790bp-1'),
+    float.fromhex('0x1.1b964efcf0d0cp-3'),
 ]
 seq0_seed12345_choices = [
-    'HT', 'D2', 'CK', 'DJ', 'S7', 'C8', 'DJ', 'DT',
-    'HA', 'D4', 'HT', 'CT', 'C7',
+    'S7', 'S3', 'D9', 'DT', 'SJ', 'DT', 'S5', 'S6',
+    'C8', 'S7', 'C9', 'HK', 'DQ'
 ]
 seq0_seed12345_sample = [
-    'HT', 'C3', 'C8', 'DA', 'CA', 'D6', 'C6', 'H9',
-    'SK', 'H8', 'HJ', 'H2', 'H6',
+    'C8', 'S5', 'D6', 'DK', 'CK', 'S9', 'C2', 'HJ',
+    'SK', 'S7', 'D2', 'C6', 'C5',
 ]
 seq0_seed12345_shuffle = [
-    5, 19, 1, 14, 10, 8, 11, 15, 18, 12,
-    3, 7, 4, 2, 17, 0, 13, 6, 9, 16,
+    19, 1, 9, 5, 18, 2, 15, 8, 6, 3,
+    4, 0, 14, 10, 12, 11, 13, 16, 17, 7,
 ]
 
 
@@ -74,10 +74,10 @@ def count_samples_generated(gen):
         del gen._next_word
 
 
-class Test_PCG_XSH_RR_V0(unittest.TestCase):
+class Test_PCG_XSL_RR_V0(unittest.TestCase):
     def test_creation_without_seed(self):
-        gen1 = PCG_XSH_RR_V0()
-        gen2 = PCG_XSH_RR_V0()
+        gen1 = PCG_XSL_RR_V0()
+        gen2 = PCG_XSL_RR_V0()
 
         sample1 = [gen1.random() for _ in range(10)]
         sample2 = [gen2.random() for _ in range(10)]
@@ -87,7 +87,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.assertNotEqual(sample1, sample2)
 
     def test_seed_resets_gauss_state(self):
-        gen = PCG_XSH_RR_V0()
+        gen = PCG_XSL_RR_V0()
 
         gen.seed(2143)
         x1 = gen.random()
@@ -101,7 +101,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.assertEqual(y1, y2)
 
     def test_reproducibility(self):
-        gen = PCG_XSH_RR_V0(seed=12345, sequence=0)
+        gen = PCG_XSL_RR_V0(seed=12345, sequence=0)
         die_rolls = [gen.randint(1, 6) for _ in range(20)]
         self.assertEqual(
             die_rolls,
@@ -111,11 +111,11 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         # Assumes IEEE 754 binary64 floats. For other formats, we'd only expect
         # to get approximate equality here. If this ever actually breaks on
         # anyone's machine, please report to me and I'll fix it.
-        gen = PCG_XSH_RR_V0(seed=12345, sequence=0)
+        gen = PCG_XSL_RR_V0(seed=12345, sequence=0)
         uniforms = [gen.random() for _ in range(10)]
         self.assertEqual(uniforms, seq0_seed12345_uniforms)
 
-        gen = PCG_XSH_RR_V0(seed=12345, sequence=0)
+        gen = PCG_XSL_RR_V0(seed=12345, sequence=0)
         suits = 'SHDC'
         values = 'AKQJT98765432'
         cards = [suit+value for suit in suits for value in values]
@@ -134,8 +134,8 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.assertEqual(population, seq0_seed12345_shuffle)
 
     def test_sequence_default(self):
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345)
+        gen1 = PCG_XSL_RR_V0(seed=12345, sequence=0)
+        gen2 = PCG_XSL_RR_V0(seed=12345)
         self.assertEqual(gen1.getstate(), gen2.getstate())
 
     def test_independent_sequences(self):
@@ -146,8 +146,8 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         # normally distributed with mean 0 and standard deviation 1 /
         # (12*sqrt(N)). So we expect |V| to be at most 1 / (4*sqrt(N)) with
         # over 99% probability.
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345, sequence=1)
+        gen1 = PCG_XSL_RR_V0(seed=12345, sequence=0)
+        gen2 = PCG_XSL_RR_V0(seed=12345, sequence=1)
         N = 10000
         xs = [gen1.random() for _ in range(N)]
         ys = [gen2.random() for _ in range(N)]
@@ -157,20 +157,20 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
 
     def test_no_shared_state(self):
         # Get samples first from gen1, then from gen2.
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345, sequence=1)
+        gen1 = PCG_XSL_RR_V0(seed=12345, sequence=0)
+        gen2 = PCG_XSL_RR_V0(seed=12345, sequence=1)
         sample1_1 = [gen1.random() for _ in range(10)]
         sample2_1 = [gen2.random() for _ in range(10)]
 
         # Now in the opposite order: from gen2, then from gen1.
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345, sequence=1)
+        gen1 = PCG_XSL_RR_V0(seed=12345, sequence=0)
+        gen2 = PCG_XSL_RR_V0(seed=12345, sequence=1)
         sample2_2 = [gen2.random() for _ in range(10)]
         sample1_2 = [gen1.random() for _ in range(10)]
 
         # Now interleaved.
-        gen1 = PCG_XSH_RR_V0(seed=12345, sequence=0)
-        gen2 = PCG_XSH_RR_V0(seed=12345, sequence=1)
+        gen1 = PCG_XSL_RR_V0(seed=12345, sequence=0)
+        gen2 = PCG_XSL_RR_V0(seed=12345, sequence=1)
         sample1_3 = []
         sample2_3 = []
         for _ in range(10):
@@ -184,7 +184,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.assertEqual(sample2_1, sample2_3)
 
     def test_save_and_restore_state(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=27)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=27)
 
         # Generate some values.
         [gen.random() for _ in range(10)]
@@ -199,16 +199,16 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.assertEqual(samples2, samples3)
 
     def test_restore_state_from_different_generator(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=27)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=27)
         state = gen.getstate()
 
-        bad_version = 'pcgrandom.PCG_XSH_RR_V1'
+        bad_version = 'pcgrandom.PCG_XSL_RR_V1'
         bad_state = (bad_version,) + state[1:]
         with self.assertRaises(ValueError):
             gen.setstate(bad_state)
 
     def test_state_preserves_gauss(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=27)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=27)
 
         # Test a state with gauss_next = None
         state = gen.getstate()
@@ -225,14 +225,14 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.assertEqual(samples1, samples2)
 
     def test_getrandbits(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         k = 5
         samples = [gen.getrandbits(k) for _ in range(10000)]
         self.check_uniform(range(2**k), samples)
 
     def test_getrandbits_large(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         k = 379
         samples = [gen.getrandbits(k) for _ in range(1000)]
@@ -244,17 +244,17 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.assertGreaterEqual(max(samples), 2**378)
 
     def test_getrandbits_zero_bits(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
         result = gen.getrandbits(0)
         self.assertEqual(result, 0)
 
     def test_getrandbits_negative_bits(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
         with self.assertRaises(ValueError):
             gen.getrandbits(-1)
 
     def test_randrange_uniform(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         # Indirect test of our _randbelow override.
         n = 13
@@ -263,7 +263,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
 
     def test_randrange_one(self):
         # Corner case.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
         state_before = gen.getstate()
 
         samples = [gen.randrange(1) for _ in range(10)]
@@ -273,25 +273,25 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.assertEqual(state_before, state_after)
 
     def test_randrange_of_wordsize(self):
-        # Using randrange(2**32) should consume exactly one
+        # Using randrange(2**64) should consume exactly one
         # sample each time.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         with count_samples_generated(gen) as wordgen:
             for index in range(10000):
                 self.assertEqual(wordgen.call_count, index)
-                gen.randrange(2**32)
+                gen.randrange(2**64)
                 self.assertEqual(wordgen.call_count, index+1)
 
     def test_jumpahead(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
         # Generate samples, each sample consuming exactly one word
         # from the core generator.
-        samples = [gen.randrange(2**32) for _ in range(1000)]
+        samples = [gen.randrange(2**64) for _ in range(1000)]
 
         # Rewind, check we can produce the exact same samples.
         gen.jumpahead(-1000)
-        same_again = [gen.randrange(2**32) for _ in range(1000)]
+        same_again = [gen.randrange(2**64) for _ in range(1000)]
         self.assertEqual(samples, same_again)
 
         # Corner case: jumpahead(0) should work.
@@ -302,18 +302,18 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
 
         # Now jump around randomly within the collection of samples. Use a
         # separate generator for the positions to jump to.
-        posgen = PCG_XSH_RR_V0(seed=19733, sequence=22)
+        posgen = PCG_XSL_RR_V0(seed=19733, sequence=22)
 
         current_pos = 1000
         for _ in range(100):
             next_pos = posgen.randrange(1000)
             gen.jumpahead(next_pos - current_pos)
-            sample = gen.randrange(2**32)
+            sample = gen.randrange(2**64)
             self.assertEqual(sample, samples[next_pos])
             current_pos = next_pos + 1
 
     def test_randrange_float_arguments(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         with self.assertRaises(TypeError):
             gen.randrange(5.0)
@@ -328,7 +328,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
 
     def test_randrange_start_only(self):
         # See http://bugs.python.org/issue9379 for related discussion.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
         samples = [gen.randrange(23) for _ in range(1000)]
         # Chance of getting only 22 of the possible 23 outcomes is < 1.2e-18.
         self.assertEqual(set(samples), set(range(23)))
@@ -339,7 +339,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
             gen.randrange(-5)
 
     def test_randrange_start_and_stop(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
         samples = [gen.randrange(-10, 13) for _ in range(1000)]
         self.assertEqual(set(samples), set(range(-10, 13)))
 
@@ -349,7 +349,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
             gen.randrange(21, 20)
 
     def test_randrange_start_stop_and_step(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         test_ranges = [
             (16, 37, 5),
@@ -377,7 +377,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
             gen.randrange(47, 47, 1)
 
     def test_choice(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         with self.assertRaises(IndexError):
             gen.choice([])
@@ -390,28 +390,28 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.check_uniform(seq, choices)
 
     def test_sample(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         samples = [tuple(gen.sample(range(4), 3)) for _ in range(10000)]
         population = list(itertools.permutations(range(4), 3))
         self.check_uniform(population, samples)
 
     def test_sample_set(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         s = set('ABCDEFG')
         sample = gen.sample(s, 3)
         self.assertLess(set(sample), s)
 
     def test_sample_dict(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         d = dict(a=1, b=2, c=3)
         with self.assertRaises(TypeError):
             gen.sample(d, 2)
 
     def test_sample_corner_cases(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
         self.assertEqual(gen.sample([], 0), [])
         with self.assertRaises(ValueError):
             self.assertEqual(gen.sample([], 1))
@@ -419,7 +419,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
             self.assertEqual(gen.sample([], -1))
 
     def test_shuffle(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
         population = list(range(13))
 
         result = gen.shuffle(population)
@@ -441,7 +441,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
 
     def test_shuffle_corner_cases(self):
         # shuffling a length 0 or 1 sequence shouldn't be a problem
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
         population = []
         gen.shuffle(population)
         self.assertEqual(population, [])
@@ -451,7 +451,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.assertEqual(population, [13])
 
     def test_choices(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         population = list(range(5))
 
@@ -468,7 +468,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
 
     def test_choices_subnormal_weights(self):
         # Corner case where random.Random triggers an IndexError.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         population = list(range(5))
         weights = [1e-323, 0.0, 2e-323, 2e-323, 1e-323]
@@ -481,7 +481,7 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
         self.check_goodness_of_fit(dict(zip(population, weights)), sample)
 
     def test_choices_error_conditions(self):
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         # Can't specify both weights and cum_weights.
         with self.assertRaises(TypeError):
@@ -522,17 +522,17 @@ class Test_PCG_XSH_RR_V0(unittest.TestCase):
     def test_count_samples_generated(self):
         # This is really a test for our count_samples_generated helper
         # rather than for the PRNG.
-        gen = PCG_XSH_RR_V0(seed=15206, sequence=1729)
+        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
 
         [gen.randrange(13) for _ in range(14)]
         with count_samples_generated(gen) as wordgen:
             [gen.randrange(27) for _ in range(21)]
             self.assertEqual(wordgen.call_count, 21)
             [gen.random() for _ in range(10)]
-            self.assertEqual(wordgen.call_count, 41)
+            self.assertEqual(wordgen.call_count, 31)
 
         [gen.randrange(27) for _ in range(13)]
-        self.assertEqual(wordgen.call_count, 41)
+        self.assertEqual(wordgen.call_count, 31)
 
     def check_uniform(self, population, sample):
         """

--- a/pcgrandom/test/test_pcg_xsl_rr_v0.py
+++ b/pcgrandom/test/test_pcg_xsl_rr_v0.py
@@ -3,13 +3,12 @@ Tests for the PCG_XSL_RR_V0 generator.
 """
 from __future__ import division
 
-import collections
 import contextlib
-import itertools
 import math
 import unittest
 
 from pcgrandom.pcg_xsl_rr_v0 import PCG_XSL_RR_V0
+from pcgrandom.test.test_common import TestCommon
 
 
 # Sequences used for detecting reproducibility regressions.
@@ -74,7 +73,11 @@ def count_samples_generated(gen):
         del gen._next_word
 
 
-class Test_PCG_XSL_RR_V0(unittest.TestCase):
+class Test_PCG_XSL_RR_V0(TestCommon, unittest.TestCase):
+
+    def setUp(self):
+        self.gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
+
     def test_creation_without_seed(self):
         gen1 = PCG_XSL_RR_V0()
         gen2 = PCG_XSL_RR_V0()
@@ -224,54 +227,6 @@ class Test_PCG_XSL_RR_V0(unittest.TestCase):
         samples2 = [gen.gauss(0.0, 1.0) for _ in range(5)]
         self.assertEqual(samples1, samples2)
 
-    def test_getrandbits(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        k = 5
-        samples = [gen.getrandbits(k) for _ in range(10000)]
-        self.check_uniform(range(2**k), samples)
-
-    def test_getrandbits_large(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        k = 379
-        samples = [gen.getrandbits(k) for _ in range(1000)]
-
-        self.assertGreaterEqual(min(samples), 0)
-        self.assertLess(max(samples), 2**379)
-        # It's possible, but vanishingly unlikely, that all values
-        # are less than 2**378.
-        self.assertGreaterEqual(max(samples), 2**378)
-
-    def test_getrandbits_zero_bits(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-        result = gen.getrandbits(0)
-        self.assertEqual(result, 0)
-
-    def test_getrandbits_negative_bits(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-        with self.assertRaises(ValueError):
-            gen.getrandbits(-1)
-
-    def test_randrange_uniform(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        # Indirect test of our _randbelow override.
-        n = 13
-        samples = [gen.randrange(n) for _ in range(10000)]
-        self.check_uniform(range(n), samples)
-
-    def test_randrange_one(self):
-        # Corner case.
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-        state_before = gen.getstate()
-
-        samples = [gen.randrange(1) for _ in range(10)]
-        self.assertEqual(samples, [0]*10)
-
-        state_after = gen.getstate()
-        self.assertEqual(state_before, state_after)
-
     def test_randrange_of_wordsize(self):
         # Using randrange(2**64) should consume exactly one
         # sample each time.
@@ -312,213 +267,6 @@ class Test_PCG_XSL_RR_V0(unittest.TestCase):
             self.assertEqual(sample, samples[next_pos])
             current_pos = next_pos + 1
 
-    def test_randrange_float_arguments(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        with self.assertRaises(TypeError):
-            gen.randrange(5.0)
-        with self.assertRaises(TypeError):
-            gen.randrange(2.0, 7)
-        with self.assertRaises(TypeError):
-            gen.randrange(2, 7.0)
-        with self.assertRaises(TypeError):
-            gen.randrange(2, 7, 1.0)
-        with self.assertRaises(TypeError):
-            gen.randrange(2, 7, 2.0)
-
-    def test_randrange_start_only(self):
-        # See http://bugs.python.org/issue9379 for related discussion.
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-        samples = [gen.randrange(23) for _ in range(1000)]
-        # Chance of getting only 22 of the possible 23 outcomes is < 1.2e-18.
-        self.assertEqual(set(samples), set(range(23)))
-
-        with self.assertRaises(ValueError):
-            gen.randrange(0)
-        with self.assertRaises(ValueError):
-            gen.randrange(-5)
-
-    def test_randrange_start_and_stop(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-        samples = [gen.randrange(-10, 13) for _ in range(1000)]
-        self.assertEqual(set(samples), set(range(-10, 13)))
-
-        with self.assertRaises(ValueError):
-            gen.randrange(20, 20)
-        with self.assertRaises(ValueError):
-            gen.randrange(21, 20)
-
-    def test_randrange_start_stop_and_step(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        test_ranges = [
-            (16, 37, 5),
-            (5, 35, 5),
-            (4, 35, 5),
-            (35, 5, -5),
-            (36, 5, -5),
-        ]
-
-        for test_range in test_ranges:
-            samples = [gen.randrange(*test_range) for _ in range(1000)]
-            self.assertEqual(set(samples), set(range(*test_range)))
-
-        with self.assertRaises(ValueError):
-            gen.randrange(0, 20, 0)
-        with self.assertRaises(ValueError):
-            gen.randrange(0, -20, 0)
-        with self.assertRaises(ValueError):
-            gen.randrange(0, 5, -1)
-        with self.assertRaises(ValueError):
-            gen.randrange(0, -5, 1)
-        with self.assertRaises(ValueError):
-            gen.randrange(22, 22, -1)
-        with self.assertRaises(ValueError):
-            gen.randrange(47, 47, 1)
-
-    def test_choice(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        with self.assertRaises(IndexError):
-            gen.choice([])
-
-        nsamples = 1000
-        seq = "ABCD"
-        choices = [
-            gen.choice(seq) for _ in range(nsamples)
-        ]
-        self.check_uniform(seq, choices)
-
-    def test_sample(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        samples = [tuple(gen.sample(range(4), 3)) for _ in range(10000)]
-        population = list(itertools.permutations(range(4), 3))
-        self.check_uniform(population, samples)
-
-    def test_sample_set(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        s = set('ABCDEFG')
-        sample = gen.sample(s, 3)
-        self.assertLess(set(sample), s)
-
-    def test_sample_dict(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        d = dict(a=1, b=2, c=3)
-        with self.assertRaises(TypeError):
-            gen.sample(d, 2)
-
-    def test_sample_corner_cases(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-        self.assertEqual(gen.sample([], 0), [])
-        with self.assertRaises(ValueError):
-            self.assertEqual(gen.sample([], 1))
-        with self.assertRaises(ValueError):
-            self.assertEqual(gen.sample([], -1))
-
-    def test_shuffle(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-        population = list(range(13))
-
-        result = gen.shuffle(population)
-        self.assertIsNone(result)
-        self.assertNotEqual(population, list(range(13)))
-        self.assertEqual(set(population), set(range(13)))
-
-        population = list(range(4))
-
-        samples = []
-        for _ in range(10000):
-            gen.shuffle(population)
-            samples.append(tuple(population))
-
-        self.check_uniform(
-            list(itertools.permutations(range(4))),
-            samples,
-        )
-
-    def test_shuffle_corner_cases(self):
-        # shuffling a length 0 or 1 sequence shouldn't be a problem
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-        population = []
-        gen.shuffle(population)
-        self.assertEqual(population, [])
-
-        population = [13]
-        gen.shuffle(population)
-        self.assertEqual(population, [13])
-
-    def test_choices(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        population = list(range(5))
-
-        sample = gen.choices(population, k=10000)
-        self.check_uniform(population, sample)
-
-        weights = [2, 3, 0, 1, 4]
-        sample = gen.choices(population, weights=weights, k=10000)
-        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
-
-        cum_weights = [2, 5, 5, 6, 10]
-        sample = gen.choices(population, cum_weights=cum_weights, k=10000)
-        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
-
-    def test_choices_subnormal_weights(self):
-        # Corner case where random.Random triggers an IndexError.
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        population = list(range(5))
-        weights = [1e-323, 0.0, 2e-323, 2e-323, 1e-323]
-        sample = gen.choices(population, weights=weights, k=10000)
-        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
-
-        population = list(range(6))
-        weights = [1e-323, 0.0, 2e-323, 2e-323, 1e-323, 0.0]
-        sample = gen.choices(population, weights=weights, k=10000)
-        self.check_goodness_of_fit(dict(zip(population, weights)), sample)
-
-    def test_choices_error_conditions(self):
-        gen = PCG_XSL_RR_V0(seed=15206, sequence=1729)
-
-        # Can't specify both weights and cum_weights.
-        with self.assertRaises(TypeError):
-            gen.choices(range(3), weights=[1, 2, 3], cum_weights=[1, 3, 6])
-
-        # Two errors here: empty population, and both weights and cum_weights
-        # specified. The TypeError for the bad signature should win.
-        with self.assertRaises(TypeError):
-            gen.choices([], weights=[1, 2, 3], cum_weights=[1, 3, 6])
-
-        # Empty population: IndexError to match random.choice. We should get an
-        # exception even in the corner case that zero samples are requested.
-        with self.assertRaises(IndexError):
-            gen.choices([], weights=[])
-        with self.assertRaises(IndexError):
-            gen.choices([], cum_weights=[])
-        with self.assertRaises(IndexError):
-            gen.choices([])
-        with self.assertRaises(IndexError):
-            gen.choices([], weights=[], k=0)
-        with self.assertRaises(IndexError):
-            gen.choices([], cum_weights=[], k=0)
-        with self.assertRaises(IndexError):
-            gen.choices([], k=0)
-
-        # Number of weights doesn't match population.
-        with self.assertRaises(ValueError):
-            gen.choices(range(3), weights=[1, 2])
-        with self.assertRaises(ValueError):
-            gen.choices(range(3), cum_weights=[1, 2])
-
-        # Total weight is zero.
-        with self.assertRaises(ValueError):
-            gen.choices(range(3), weights=[0.0, 0.0, 0.0])
-        with self.assertRaises(ValueError):
-            gen.choices(range(3), cum_weights=[0.0, 0.0, 0.0])
-
     def test_count_samples_generated(self):
         # This is really a test for our count_samples_generated helper
         # rather than for the PRNG.
@@ -533,48 +281,3 @@ class Test_PCG_XSL_RR_V0(unittest.TestCase):
 
         [gen.randrange(27) for _ in range(13)]
         self.assertEqual(wordgen.call_count, 31)
-
-    def check_uniform(self, population, sample):
-        """
-        Check uniformity via a chi-squared test with p-value 0.99.
-
-        Requires that there's an entry for len(population) - 1
-        in the chisq_99percentile dictionary.
-
-        Parameters
-        ----------
-        population : sequence
-            The population that the samples are drawn from.
-        sample : sequence
-            The generated sample.
-        """
-        weights = {i: 1 for i in population}
-        self.check_goodness_of_fit(weights, sample)
-
-    def check_goodness_of_fit(self, weights, sample):
-        """
-        Perform a chi-squared goodness of fit test.
-
-        Requires that there's an entry for len(expected) - 1
-        in the chisq_99percentile dictionary.
-
-        sample : the sample to be tested
-        weights : mapping from members of the population to their
-            expected weights. The weights need not be normalised.
-        """
-        counts = collections.Counter(sample)
-        # Expected frequencies for this sample.
-        total = sum(weights.values())
-        expected = {
-            i: w / total * len(sample) for i, w in weights.items() if w}
-
-        # Check that we don't have any extraneous objects in our sample.  This
-        # also acts as a check that elements with zero weight haven't been
-        # generated.
-        self.assertLessEqual(set(counts), set(expected))
-
-        stat = sum(
-            (counts[i] - expected[i])**2 / expected[i]
-            for i in expected
-        )
-        self.assertLess(stat, chisq_99percentile[len(expected)-1])


### PR DESCRIPTION
Add implementation of PCG-XSL-RR from section 6.3.3 of the PCG paper (128-bit state, 64-bit output); refactor to remove duplication between implementations and tests.