### PR TITLE
Make versions unicode for better compatibility

### DIFF
--- a/pcgrandom/pcg_common.py
+++ b/pcgrandom/pcg_common.py
@@ -34,7 +34,7 @@ class PCGCommon(_random.Random):
         # changes.  See also http://bugs.python.org/issue27706.
         if seed is None:
             nbytes = self._state_bits // 8
-            seed = _int.from_bytes(_os.urandom(nbytes), byteorder='little')
+            seed = _int.from_bytes(_os.urandom(nbytes), byteorder="little")
         else:
             seed = _operator.index(seed)
 
@@ -181,9 +181,9 @@ class PCGCommon(_random.Random):
 
         # Left-to-right binary powering algorithm.
         an, cn = 1, 0
-        for bit in format(n, 'b'):
+        for bit in format(n, "b"):
             an, cn = an * an & m, an * cn + cn & m
-            if bit == '1':
+            if bit == "1":
                 an, cn = a * an & m, a * cn + c & m
 
         self._state = self._state * an + cn & m
@@ -200,7 +200,7 @@ class PCGCommon(_random.Random):
     def shuffle(self, x):
         """Shuffle list x in place, and return None."""
         # XXX Compatibility note: shuffle does not support the
-        # second 'random' argument.
+        # second "random" argument.
 
         n = len(x)
         for i in reversed(_range(n)):

--- a/pcgrandom/pcg_xsh_rr_v0.py
+++ b/pcgrandom/pcg_xsh_rr_v0.py
@@ -15,6 +15,8 @@
 #     compatibility.
 # XXX Rework reproducibility tests: JSON format for the results might work.
 
+from __future__ import unicode_literals
+
 from pcgrandom.pcg_common import PCGCommon as _PCGCommon
 
 

--- a/pcgrandom/pcg_xsh_rr_v0.py
+++ b/pcgrandom/pcg_xsh_rr_v0.py
@@ -15,8 +15,6 @@
 #     compatibility.
 # XXX Rework reproducibility tests: JSON format for the results might work.
 
-from __future__ import unicode_literals
-
 from pcgrandom.pcg_common import PCGCommon as _PCGCommon
 
 
@@ -54,7 +52,7 @@ class PCG_XSH_RR_V0(_PCGCommon):
     PCG-XSH-RR, sitting on a 64-bit LCG from Knuth.
     """
 
-    VERSION = "pcgrandom.PCG_XSH_RR_V0"
+    VERSION = u"pcgrandom.PCG_XSH_RR_V0"
 
     _state_bits = 64
 

--- a/pcgrandom/pcg_xsl_rr_v0.py
+++ b/pcgrandom/pcg_xsl_rr_v0.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from pcgrandom.pcg_common import PCGCommon as _PCGCommon
 
 
@@ -44,7 +42,7 @@ class PCG_XSL_RR_V0(_PCGCommon):
     PCG-XSL-RR, sitting on a 128-bit LCG with multiplier from L'Ecuyer.
     """
 
-    VERSION = "pcgrandom.PCG_XSL_RR_V0"
+    VERSION = u"pcgrandom.PCG_XSL_RR_V0"
 
     _state_bits = 128
 

--- a/pcgrandom/pcg_xsl_rr_v0.py
+++ b/pcgrandom/pcg_xsl_rr_v0.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from pcgrandom.pcg_common import PCGCommon as _PCGCommon
 
 

--- a/pcgrandom/test/test_common.py
+++ b/pcgrandom/test/test_common.py
@@ -20,6 +20,9 @@ chisq_99percentile = {
 
 
 class TestCommon(object):
+    def test_version_is_unicode(self):
+        self.assertIsInstance(self.gen.VERSION, type(u''))
+
     def test_creation_without_seed(self):
         gen1 = self.gen_class()
         gen2 = self.gen_class()


### PR DESCRIPTION
Make sure the generator version string is always Unicode, regardless of Python version. Also fixes some quoting inconsistencies.