### PR TITLE
Allow specification of multiplier when creating PCG.

### DIFF
--- a/pcgrandom/pcg_xsh_rr_v0.py
+++ b/pcgrandom/pcg_xsh_rr_v0.py
@@ -59,7 +59,7 @@ class PCG_XSH_RR_V0(_PCGCommon):
     _output_bits = 32
 
     # Multiplier reportedly used by Knuth for the MMIX LCG.
-    _multiplier = 6364136223846793005
+    _default_multiplier = 6364136223846793005
 
     # Increment reportedly used by Knuth for the MMIX LCG.
     _base_increment = 1442695040888963407

--- a/pcgrandom/pcg_xsl_rr_v0.py
+++ b/pcgrandom/pcg_xsl_rr_v0.py
@@ -48,7 +48,7 @@ class PCG_XSL_RR_V0(_PCGCommon):
 
     _output_bits = 64
 
-    _multiplier = _LECUYER_MULTIPLIER
+    _default_multiplier = _LECUYER_MULTIPLIER
 
     _base_increment = _128BIT_INCREMENT
 

--- a/pcgrandom/pcg_xsl_rr_v0.py
+++ b/pcgrandom/pcg_xsl_rr_v0.py
@@ -1,15 +1,11 @@
 from pcgrandom.pcg_common import PCGCommon as _PCGCommon
 
+# Reference for multiplier: "Tables of linear congruential generators of
+# different sizes and good lattice stucture", Pierre L'Ecuyer, Mathematics of
+# Computation vol. 68, no. 225, January 1999, pp 249-260.
+
 
 _UINT64_MASK = 2**64 - 1
-
-# Constant from Table 4 of "Tables of linear congruential generators of
-# different sizes and good lattice stucture", Pierre L'Ecuyer, Mathematics of
-# Computation vol. 68, no. 225, January 1999, pp 249-260. The increment is
-# chosen randomly.
-_LECUYER_MULTIPLIER = 47026247687942121848144207491837523525
-_128BIT_INCREMENT = 209568312854995847869081903677183368518
-
 
 def _rotate64(v, r):
     """
@@ -48,9 +44,11 @@ class PCG_XSL_RR_V0(_PCGCommon):
 
     _output_bits = 64
 
-    _default_multiplier = _LECUYER_MULTIPLIER
+    # Multiplier from Table 4 of L'Ecuyer's paper.
+    _default_multiplier = 47026247687942121848144207491837523525
 
-    _base_increment = _128BIT_INCREMENT
+    # A somewhat arbitrary increment.
+    _base_increment = 209568312854995847869081903677183368518
 
     def _get_output(self):
         """Compute output from current state."""

--- a/pcgrandom/test/test_common.py
+++ b/pcgrandom/test/test_common.py
@@ -34,6 +34,21 @@ class TestCommon(object):
         # unlikely in practice.
         self.assertNotEqual(sample1, sample2)
 
+    def test_specification_of_multiplier(self):
+        gen = self.gen_class(seed=123, sequence=0, multiplier=5)
+        for _ in range(10):
+            old_state = gen._state
+            gen._advance_state()
+            new_state = gen._state
+            self.assertEqual(
+                new_state,
+                (old_state * 5 + gen._increment) % (2**gen._state_bits)
+            )
+
+    def test_bad_multiplier(self):
+        with self.assertRaises(ValueError):
+            self.gen_class(seed=123, sequence=0, multiplier=7)
+
     def test_sequence_default(self):
         gen1 = self.gen_class(seed=12345, sequence=0)
         gen2 = self.gen_class(seed=12345)

--- a/pcgrandom/test/test_common.py
+++ b/pcgrandom/test/test_common.py
@@ -45,6 +45,16 @@ class TestCommon(object):
                 (old_state * 5 + gen._increment) % (2**gen._state_bits)
             )
 
+    def test_state_includes_multiplier(self):
+        gen = self.gen_class(seed=123, sequence=0, multiplier=5)
+        state = gen.getstate()
+        words = [gen._next_output() for _ in range(10)]
+
+        gen2 = self.gen_class()
+        gen2.setstate(state)
+        same_again = [gen2._next_output() for _ in range(10)]
+        self.assertEqual(words, same_again)
+
     def test_bad_multiplier(self):
         with self.assertRaises(ValueError):
             self.gen_class(seed=123, sequence=0, multiplier=7)


### PR DESCRIPTION
Since the PCG paper doesn't give explicit multipliers for the underlying LCG, and because one of the purposes of this library is to allow experimentation, we should make it possible to use a different multiplier from the default one for each PCG. Note that the multiplier is already part of the state.

Note: use this feature with caution! Selecting a good multiplier is hard.