### PR TITLE
Fix the even increment for PCG_XSL_RR_V0.

### DIFF
--- a/pcgrandom/pcg_xsl_rr_v0.py
+++ b/pcgrandom/pcg_xsl_rr_v0.py
@@ -47,8 +47,8 @@ class PCG_XSL_RR_V0(_PCGCommon):
     # Multiplier from Table 4 of L'Ecuyer's paper.
     _default_multiplier = 47026247687942121848144207491837523525
 
-    # A somewhat arbitrary increment.
-    _base_increment = 209568312854995847869081903677183368518
+    # A somewhat arbitrary increment, chosen at random.
+    _base_increment = 209568312854995847869081903677183368519
 
     def _get_output(self):
         """Compute output from current state."""

--- a/pcgrandom/test/test_common.py
+++ b/pcgrandom/test/test_common.py
@@ -159,6 +159,26 @@ class TestCommon(object):
         self.gen.jumpahead(0)
         self.assertEqual(self.gen.getstate(), state)
 
+    def test_invertible(self):
+        gen = self.gen_class(seed=12345)
+        state = gen.getstate()
+        gen.jumpahead(-1)
+        gen._next_output()
+        self.assertEqual(gen.getstate(), state)
+
+    def test_full_period(self):
+        gen = self.gen_class(seed=12345)
+        expected_period = 2**gen._state_bits
+        half_period = expected_period // 2
+
+        state_start = gen.getstate()
+        gen.jumpahead(half_period)
+        state_half = gen.getstate()
+        gen.jumpahead(half_period)
+        state_full = gen.getstate()
+        self.assertEqual(state_start, state_full)
+        self.assertNotEqual(state_start, state_half)
+
     def test_state_preserves_gauss(self):
         # Test a state with gauss_next = None
         state = self.gen.getstate()

--- a/pcgrandom/test/test_pcg_xsl_rr_v0.py
+++ b/pcgrandom/test/test_pcg_xsl_rr_v0.py
@@ -11,30 +11,29 @@ from pcgrandom.test.test_common import TestCommon
 
 # Sequences used for detecting reproducibility regressions.
 seq0_seed12345_die_rolls = [
-    1, 2, 4, 4, 1, 4, 2, 2, 6, 1, 6, 2, 4, 6, 6, 5, 1, 1, 2, 6]
+    2, 2, 1, 6, 4, 2, 1, 5, 2, 3, 5, 5, 2, 1, 6, 5, 6, 4, 2, 2]
 seq0_seed12345_uniforms = [
-    float.fromhex('0x1.36feb111851b8p-3'),
-    float.fromhex('0x1.d0eab4d2dacd0p-3'),
-    float.fromhex('0x1.3153584d8fc39p-1'),
-    float.fromhex('0x1.2839f1285a962p-1'),
-    float.fromhex('0x1.dd8596e786ab0p-5'),
-    float.fromhex('0x1.295b84d5041f7p-1'),
-    float.fromhex('0x1.86227587a6c34p-3'),
-    float.fromhex('0x1.5ac08820e8fc8p-3'),
-    float.fromhex('0x1.bbdbd5409790bp-1'),
-    float.fromhex('0x1.1b964efcf0d0cp-3'),
+    float.fromhex('0x1.914d30cdc8438p-3'),
+    float.fromhex('0x1.95559ac4dfa84p-3'),
+    float.fromhex('0x1.f3612f1f265c8p-4'),
+    float.fromhex('0x1.c87c795ddc073p-1'),
+    float.fromhex('0x1.055e2a2568177p-1'),
+    float.fromhex('0x1.12b02c291be50p-2'),
+    float.fromhex('0x1.3272ecbc61f98p-3'),
+    float.fromhex('0x1.6efb350d9ea00p-1'),
+    float.fromhex('0x1.11320fb1baed4p-2'),
+    float.fromhex('0x1.a1142b39a5370p-2'),
 ]
 seq0_seed12345_choices = [
-    'S7', 'S3', 'D9', 'DT', 'SJ', 'DT', 'S5', 'S6',
-    'C8', 'S7', 'C9', 'HK', 'DQ'
-]
+    'S4', 'S4', 'S8', 'C7', 'DA', 'HA', 'S7', 'D3',
+    'HA', 'H6', 'D2', 'CQ', 'S2']
 seq0_seed12345_sample = [
-    'C8', 'S5', 'D6', 'DK', 'CK', 'S9', 'C2', 'HJ',
-    'SK', 'S7', 'D2', 'C6', 'C5',
+    'ST', 'D4', 'C8', 'D6', 'DJ', 'H7', 'H9', 'HT',
+    'D9', 'C5', 'CJ', 'C4', 'HQ'
 ]
 seq0_seed12345_shuffle = [
-    19, 1, 9, 5, 18, 2, 15, 8, 6, 3,
-    4, 0, 14, 10, 12, 11, 13, 16, 17, 7,
+    11, 10, 1, 8, 6, 19, 18, 3, 5, 4,
+    13, 12, 16, 0, 9, 7, 2, 15, 14, 17,
 ]
 
 


### PR DESCRIPTION
A moment of inattention led to use of an even increment for the PCG_XSL_RR_V0 generator, which creates a generator with less than full period. This PR fixes that, and adds a test for full period (via jumpahead).