### PR TITLE
Add top-level package layer

### DIFF
--- a/pcgrandom/__init__.py
+++ b/pcgrandom/__init__.py
@@ -11,3 +11,78 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from pcgrandom.pcg_xsh_rr_v0 import PCG_XSH_RR_V0
+from pcgrandom.pcg_xsl_rr_v0 import PCG_XSL_RR_V0
+
+# XXX Compatibility note: from pcgrandom import * includes a few
+#     extra names, which could potentially override existing user
+#     names.
+__all__ = [
+    # Generators.
+    "PCG_XSH_RR_V0", "PCG_XSL_RR_V0",
+    # Generator synonyms
+    "PCG32", "PCG64", "Random",
+
+    # Methods related to the internal state.
+    "getstate", "jumpahead", "seed", "setstate",
+
+    # Methods of the auto-created instance: integer generators
+    "getrandbits", "randint", "randrange",
+
+    # Methods of the auto-created instance: combinatorial
+    "choice", "choices", "sample", "shuffle",
+
+    # Methods of the auto-created instance: float generators
+    "betavariate", "expovariate", "gammavariate", "gauss", "lognormvariate",
+    "normalvariate", "paretovariate", "random", "triangular", "uniform",
+    "vonmisesvariate", "weibullvariate",
+
+]
+
+# Allow users to do 'from pcgrandom import Random', to mimic standard library
+# 'random' module. Note that this may change with releases, so if
+# reproducibility is important, users should import and use the specific
+# generator.  We also provide synonyms for common generators. Again, these may
+# be updated over time to point to later versions of the same generators, or
+# possibly even to different generators. In situations where reproducibility
+# matters, avoid the synonyms and use the explicit generator name.
+Random = PCG_XSH_RR_V0
+
+PCG32 = PCG_XSH_RR_V0
+PCG64 = PCG_XSL_RR_V0
+
+# Create one instance, seeded from urandom, and export its methods
+# as module-level functions.  The functions share state across all uses
+# (both in the user's code and in the Python libraries), but that's fine
+# for most programs and is easier for the casual user than making them
+# instantiate their own Random() instance.
+
+_inst = Random()
+
+seed = _inst.seed
+getstate = _inst.getstate
+setstate = _inst.setstate
+jumpahead = _inst.jumpahead
+
+getrandbits = _inst.getrandbits
+randint = _inst.randint
+randrange = _inst.randrange
+
+choice = _inst.choice
+choices = _inst.choices
+sample = _inst.sample
+shuffle = _inst.shuffle
+
+betavariate = _inst.betavariate
+expovariate = _inst.expovariate
+gammavariate = _inst.gammavariate
+gauss = _inst.gauss
+lognormvariate = _inst.lognormvariate
+normalvariate = _inst.normalvariate
+paretovariate = _inst.paretovariate
+random = _inst.random
+triangular = _inst.triangular
+uniform = _inst.uniform
+vonmisesvariate = _inst.vonmisesvariate
+weibullvariate = _inst.weibullvariate

--- a/pcgrandom/test/test_pcgrandom.py
+++ b/pcgrandom/test/test_pcgrandom.py
@@ -1,0 +1,121 @@
+# Copyright 2017 Mark Dickinson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the pcgrandom top-level package.
+"""
+import types
+import unittest
+
+from past.builtins import long
+
+import pcgrandom
+
+from pcgrandom import (
+    PCG_XSH_RR_V0,
+    PCG32,
+    PCG64,
+    Random,
+)
+
+
+class TestPCGRandom(unittest.TestCase):
+    def test___all__(self):
+        names_in_all = set(pcgrandom.__all__)
+        public_names = {
+            name for name, obj in pcgrandom.__dict__.items()
+            if not name.startswith('_')
+            if not isinstance(obj, types.ModuleType)
+        }
+        self.assertEqual(names_in_all, public_names)
+
+    def test_random_class(self):
+        gen = pcgrandom.Random()
+        self.assertIsInstance(gen, pcgrandom.PCG_XSH_RR_V0)
+        # Exercise the generator to make sure nothing bad happens.
+        [gen.random() for _ in range(10)]
+
+    def test_pcg_32(self):
+        gen = pcgrandom.PCG32()
+        self.assertEqual(gen._output_bits, 32)
+
+    def test_pcg_64(self):
+        gen = pcgrandom.PCG64()
+        self.assertEqual(gen._output_bits, 64)
+
+    def test_float_generators(self):
+        # Just exercise the float generators to make sure that they're usable.
+        # We leave the detailed tests to Python's standard library, since these
+        # generators are inherited directly from there.
+        deviates = [
+            pcgrandom.betavariate(0.3, 0.5),
+            pcgrandom.expovariate(2.0),
+            pcgrandom.gammavariate(0.3, 0.5),
+            pcgrandom.gauss(0.0, 1.0),
+            pcgrandom.lognormvariate(3.2, 1.1),
+            pcgrandom.normalvariate(3.2, 1.1),
+            pcgrandom.paretovariate(2.5),
+            pcgrandom.random(),
+            pcgrandom.triangular(),
+            pcgrandom.uniform(5.0, 6.0),
+            pcgrandom.vonmisesvariate(0.5, 2.3),
+            pcgrandom.weibullvariate(54.0, 2.3),
+        ]
+        for deviate in deviates:
+            self.assertIsInstance(deviate, float)
+
+    def test_integer_generators(self):
+        # As above, just exercise to detect shallow errors. More stringent
+        # tests are in the tests for the individual generators.
+        deviates = [
+            pcgrandom.getrandbits(17),
+            pcgrandom.randint(5, 10),
+            pcgrandom.randrange(5, 10),
+        ]
+        for deviate in deviates:
+            self.assertIsInstance(deviate, (int, long))
+
+    def test_combinatorial_generators(self):
+        # In-depth testing is left to the unit tests for the individual
+        # generators.
+        self.assertIsInstance(pcgrandom.choice(range(5)), int)
+        self.assertIsInstance(pcgrandom.choices(range(5), k=3), list)
+        self.assertIsInstance(pcgrandom.sample(range(5), 3), list)
+        population = list(range(5))
+        pcgrandom.shuffle(population)
+        self.assertEqual(set(population), set(range(5)))
+
+    def test_get_and_set_state(self):
+        state = pcgrandom.getstate()
+        sample1 = pcgrandom.randrange(10**6)
+        pcgrandom.setstate(state)
+        sample2 = pcgrandom.randrange(10**6)
+        self.assertEqual(sample1, sample2)
+
+    def test_jumpahead(self):
+        state = pcgrandom.getstate()
+        pcgrandom.jumpahead(123456)
+        self.assertNotEqual(pcgrandom.getstate(), state)
+        pcgrandom.jumpahead(-100000)
+        self.assertNotEqual(pcgrandom.getstate(), state)
+        pcgrandom.jumpahead(-23456)
+        self.assertEqual(pcgrandom.getstate(), state)
+
+    def test_seed(self):
+        pcgrandom.seed(6789)
+        state = pcgrandom.getstate()
+        [pcgrandom.randrange(10**6) for _ in range(150)]
+        self.assertNotEqual(pcgrandom.getstate(), state)
+        pcgrandom.seed(6789)
+        self.assertEqual(pcgrandom.getstate(), state)


### PR DESCRIPTION
This makes `pcgrandom` a drop-in replacement for `random` (excluding the `SystemRandom` class).

- Add top-level `Random` class
- Add top-level functions linked to a `Random` instance
- Add synonyms `PCG32` and `PCG64`.