### PR TITLE
Implement randint directly

### DIFF
--- a/pcgrandom/pcg_common.py
+++ b/pcgrandom/pcg_common.py
@@ -152,6 +152,17 @@ class PCGCommon(_random.Random):
                 "Empty range for randrange({0}, {1}, {2}).".format(
                     istart, istop, istep))
 
+    def randint(self, a, b):
+        """Return random integer in range [a, b], including both end points.
+        """
+        istart = _operator.index(a)
+        width = _operator.index(b) - istart + 1
+        if width > 0:
+            return istart + self._randbelow(width)
+        else:
+            raise ValueError(
+                "Empty range for randint({0}, {1}).".format(a, b))
+
     def _advance_state(self):
         """Advance the underlying LCG a single step."""
         self._state = (

--- a/pcgrandom/test/test_pcg_common.py
+++ b/pcgrandom/test/test_pcg_common.py
@@ -380,6 +380,26 @@ class TestPCGCommon(object):
         for x in xs:
             self.assertIsInstance(x, int)
 
+    def test_randint_uniform(self):
+        a, b = 10, 22
+        samples = [self.gen.randint(a, b) for _ in range(10000)]
+        self.check_uniform(range(a, b+1), samples)
+
+    def test_randint_empty_range(self):
+        with self.assertRaises(ValueError):
+            self.gen.randint(7, 6)
+        with self.assertRaises(ValueError):
+            self.gen.randint(7, 5)
+        self.assertEqual(self.gen.randint(7, 7), 7)
+
+    def test_randint_float(self):
+        with self.assertRaises(TypeError):
+            self.gen.randint(1, 2.0)
+        with self.assertRaises(TypeError):
+            self.gen.randint(1.0, 2)
+        with self.assertRaises(TypeError):
+            self.gen.randint(2.0, 2)
+
     def test_choice(self):
         with self.assertRaises(IndexError):
             self.gen.choice([])


### PR DESCRIPTION
If we're serious about `randint` reproducibility, we need to implement it ourselves rather than relying on the base class implementation, which could change when the Python version changes.