### PR TITLE
Remove inheritance from random.Random (and thereby from _random.Random).

### DIFF
--- a/pcgrandom/distributions.py
+++ b/pcgrandom/distributions.py
@@ -1,0 +1,299 @@
+# Copyright 2017 Mark Dickinson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Mixin class providing various distributions.
+"""
+# The methods in this class are copied almost verbatim from Python's random
+# module.
+
+from math import (
+    acos as _acos, cos as _cos, e as _e, exp as _exp, log as _log, pi as _pi,
+    sin as _sin, sqrt as _sqrt
+)
+
+NV_MAGICCONST = 4 * _exp(-0.5)/_sqrt(2.0)
+TWOPI = 2.0*_pi
+LOG4 = _log(4.0)
+SG_MAGICCONST = 1.0 + _log(4.5)
+
+
+class Distributions(object):
+    """
+    Mixin class to be used with a PRNG, providing various distributions.
+    """
+
+    def uniform(self, a, b):
+        """Random number in the range [a, b) or [a, b] depending on rounding.
+        """
+        return a + (b-a) * self.random()
+
+    def triangular(self, low=0.0, high=1.0, mode=None):
+        """Triangular distribution.
+
+        Continuous distribution bounded by given lower and upper limits,
+        and having a given mode value in-between.
+
+        http://en.wikipedia.org/wiki/Triangular_distribution
+
+        """
+        u = self.random()
+        try:
+            c = 0.5 if mode is None else (mode - low) / (high - low)
+        except ZeroDivisionError:
+            return low
+        if u > c:
+            u = 1.0 - u
+            c = 1.0 - c
+            low, high = high, low
+        return low + (high - low) * (u * c) ** 0.5
+
+    def normalvariate(self, mu, sigma):
+        """Normal distribution.
+
+        mu is the mean, and sigma is the standard deviation.
+
+        """
+        # mu = mean, sigma = standard deviation
+
+        # Uses Kinderman and Monahan method. Reference: Kinderman,
+        # A.J. and Monahan, J.F., "Computer generation of random
+        # variables using the ratio of uniform deviates", ACM Trans
+        # Math Software, 3, (1977), pp257-260.
+
+        random = self.random
+        while 1:
+            u1 = random()
+            u2 = 1.0 - random()
+            z = NV_MAGICCONST*(u1-0.5)/u2
+            zz = z*z/4.0
+            if zz <= -_log(u2):
+                break
+        return mu + z*sigma
+
+    def lognormvariate(self, mu, sigma):
+        """Log normal distribution.
+
+        If you take the natural logarithm of this distribution, you'll get a
+        normal distribution with mean mu and standard deviation sigma.
+        mu can have any value, and sigma must be greater than zero.
+
+        """
+        return _exp(self.normalvariate(mu, sigma))
+
+    def expovariate(self, lambd):
+        """Exponential distribution.
+
+        lambd is 1.0 divided by the desired mean.  It should be
+        nonzero.  (The parameter would be called "lambda", but that is
+        a reserved word in Python.)  Returned values range from 0 to
+        positive infinity if lambd is positive, and from negative
+        infinity to 0 if lambd is negative.
+
+        """
+        # lambd: rate lambd = 1/mean
+        # ('lambda' is a Python reserved word)
+
+        # we use 1-random() instead of random() to preclude the
+        # possibility of taking the log of zero.
+        return -_log(1.0 - self.random())/lambd
+
+    def vonmisesvariate(self, mu, kappa):
+        """Circular data distribution.
+
+        mu is the mean angle, expressed in radians between 0 and 2*pi, and
+        kappa is the concentration parameter, which must be greater than or
+        equal to zero.  If kappa is equal to zero, this distribution reduces
+        to a uniform random angle over the range 0 to 2*pi.
+
+        """
+        # mu:    mean angle (in radians between 0 and 2*pi)
+        # kappa: concentration parameter kappa (>= 0)
+        # if kappa = 0 generate uniform random angle
+
+        # Based upon an algorithm published in: Fisher, N.I.,
+        # "Statistical Analysis of Circular Data", Cambridge
+        # University Press, 1993.
+
+        # Thanks to Magnus Kessler for a correction to the
+        # implementation of step 4.
+
+        random = self.random
+        if kappa <= 1e-6:
+            return TWOPI * random()
+
+        s = 0.5 / kappa
+        r = s + _sqrt(1.0 + s * s)
+
+        while 1:
+            u1 = random()
+            z = _cos(_pi * u1)
+
+            d = z / (r + z)
+            u2 = random()
+            if u2 < 1.0 - d * d or u2 <= (1.0 - d) * _exp(d):
+                break
+
+        q = 1.0 / r
+        f = (q + z) / (1.0 + q * z)
+        u3 = random()
+        if u3 > 0.5:
+            theta = (mu + _acos(f)) % TWOPI
+        else:
+            theta = (mu - _acos(f)) % TWOPI
+
+        return theta
+
+    def gammavariate(self, alpha, beta):
+        """Gamma distribution.  Not the gamma function!
+
+        Conditions on the parameters are alpha > 0 and beta > 0.
+
+        The probability distribution function is:
+
+                    x ** (alpha - 1) * math.exp(-x / beta)
+          pdf(x) =  --------------------------------------
+                      math.gamma(alpha) * beta ** alpha
+
+        """
+
+        # alpha > 0, beta > 0, mean is alpha*beta, variance is alpha*beta**2
+
+        # Warning: a few older sources define the gamma distribution in terms
+        # of alpha > -1.0
+        if alpha <= 0.0 or beta <= 0.0:
+            raise ValueError('gammavariate: alpha and beta must be > 0.0')
+
+        random = self.random
+        if alpha > 1.0:
+
+            # Uses R.C.H. Cheng, "The generation of Gamma
+            # variables with non-integral shape parameters",
+            # Applied Statistics, (1977), 26, No. 1, p71-74
+
+            ainv = _sqrt(2.0 * alpha - 1.0)
+            bbb = alpha - LOG4
+            ccc = alpha + ainv
+
+            while 1:
+                u1 = random()
+                if not 1e-7 < u1 < .9999999:
+                    continue
+                u2 = 1.0 - random()
+                v = _log(u1/(1.0-u1))/ainv
+                x = alpha*_exp(v)
+                z = u1*u1*u2
+                r = bbb+ccc*v-x
+                if r + SG_MAGICCONST - 4.5*z >= 0.0 or r >= _log(z):
+                    return x * beta
+
+        elif alpha == 1.0:
+            # expovariate(1/beta)
+            u = random()
+            while u <= 1e-7:
+                u = random()
+            return -_log(u) * beta
+
+        else:   # alpha is between 0 and 1 (exclusive)
+
+            # Uses ALGORITHM GS of Statistical Computing - Kennedy & Gentle
+
+            while 1:
+                u = random()
+                b = (_e + alpha)/_e
+                p = b*u
+                if p <= 1.0:
+                    x = p ** (1.0/alpha)
+                else:
+                    x = -_log((b-p)/alpha)
+                u1 = random()
+                if p > 1.0:
+                    if u1 <= x ** (alpha - 1.0):
+                        break
+                elif u1 <= _exp(-x):
+                    break
+            return x * beta
+
+    def gauss(self, mu, sigma):
+        """Gaussian distribution.
+
+        mu is the mean, and sigma is the standard deviation.  This is
+        slightly faster than the normalvariate() function.
+
+        Not thread-safe without a lock around calls.
+
+        """
+
+        # When x and y are two variables from [0, 1), uniformly
+        # distributed, then
+        #
+        #    cos(2*pi*x)*sqrt(-2*log(1-y))
+        #    sin(2*pi*x)*sqrt(-2*log(1-y))
+        #
+        # are two *independent* variables with normal distribution
+        # (mu = 0, sigma = 1).
+        # (Lambert Meertens)
+        # (corrected version; bug discovered by Mike Miller, fixed by LM)
+
+        # Multithreading note: When two threads call this function
+        # simultaneously, it is possible that they will receive the
+        # same return value.  The window is very small though.  To
+        # avoid this, you have to use a lock around all calls.  (I
+        # didn't want to slow this down in the serial case by using a
+        # lock here.)
+
+        random = self.random
+        z = self.gauss_next
+        self.gauss_next = None
+        if z is None:
+            x2pi = random() * TWOPI
+            g2rad = _sqrt(-2.0 * _log(1.0 - random()))
+            z = _cos(x2pi) * g2rad
+            self.gauss_next = _sin(x2pi) * g2rad
+
+        return mu + z*sigma
+
+    def betavariate(self, alpha, beta):
+        """Beta distribution.
+
+        Conditions on the parameters are alpha > 0 and beta > 0.
+        Returned values range between 0 and 1.
+
+        """
+
+        # This version due to Janne Sinkkonen, and matches all the std
+        # texts (e.g., Knuth Vol 2 Ed 3 pg 134 "the beta distribution").
+        y = self.gammavariate(alpha, 1.0)
+        if y == 0:
+            return 0.0
+        else:
+            return y / (y + self.gammavariate(beta, 1.0))
+
+    def paretovariate(self, alpha):
+        """Pareto distribution.  alpha is the shape parameter."""
+        # Jain, pg. 495
+
+        u = 1.0 - self.random()
+        return 1.0 / u ** (1.0/alpha)
+
+    def weibullvariate(self, alpha, beta):
+        """Weibull distribution.
+
+        alpha is the scale parameter and beta is the shape parameter.
+
+        """
+        # Jain, pg. 499; bug fix courtesy Bill Arms
+
+        u = 1.0 - self.random()
+        return alpha * (-_log(u)) ** (1.0/beta)

--- a/pcgrandom/pcg_common.py
+++ b/pcgrandom/pcg_common.py
@@ -21,19 +21,17 @@ import bisect as _bisect
 import collections as _collections
 import operator as _operator
 import os as _os
-import random as _random
 
 from builtins import int as _int, range as _range
 
+from pcgrandom.distributions import Distributions
 
-class PCGCommon(_random.Random):
+
+class PCGCommon(Distributions):
     """
     Common base class for the PCG random generators.
     """
     def __init__(self, seed=None, sequence=None, multiplier=None):
-        self._state_mask = ~(~0 << self._state_bits)
-        self._output_previous = self._state_bits <= 64
-
         if multiplier is None:
             multiplier = self._default_multiplier
         multiplier = _operator.index(multiplier) & self._state_mask
@@ -52,6 +50,12 @@ class PCGCommon(_random.Random):
         self._multiplier = multiplier
         self._increment = increment
         self.seed(seed)
+
+    def __getstate__(self):
+        return self.getstate()
+
+    def __setstate__(self, state):
+        self.setstate(state)
 
     def seed(self, seed=None):
         """Initialize internal state from hashable object.
@@ -174,17 +178,6 @@ class PCGCommon(_random.Random):
             self._state * self._multiplier + self._increment
             & self._state_mask
         )
-
-    def _next_output(self):
-        """Return next output; advance the underlying LCG.
-        """
-        if self._output_previous:
-            output = self._get_output()
-            self._advance_state()
-        else:
-            self._advance_state()
-            output = self._get_output()
-        return output
 
     def _set_state_from_seed(self, seed):
         """Initialize generator from a given seed.

--- a/pcgrandom/pcg_xsh_rr_v0.py
+++ b/pcgrandom/pcg_xsh_rr_v0.py
@@ -51,6 +51,8 @@ class PCG_XSH_RR_V0(_PCGCommon):
 
     _state_bits = 64
 
+    _state_mask = 2**64 - 1
+
     _output_bits = 32
 
     # Multiplier reportedly used by Knuth for the MMIX LCG. Same as the
@@ -65,3 +67,10 @@ class PCG_XSH_RR_V0(_PCGCommon):
         """Compute output from current state."""
         state = self._state
         return _rotate32((state ^ (state >> 18)) >> 27, state >> 59)
+
+    def _next_output(self):
+        """Return next output; advance the underlying LCG.
+        """
+        output = self._get_output()
+        self._advance_state()
+        return output

--- a/pcgrandom/pcg_xsh_rs_v0.py
+++ b/pcgrandom/pcg_xsh_rs_v0.py
@@ -27,6 +27,8 @@ class PCG_XSH_RS_V0(_PCGCommon):
 
     _state_bits = 64
 
+    _state_mask = 2**64 - 1
+
     _output_bits = 32
 
     # Multiplier reportedly used by Knuth for the MMIX LCG.
@@ -39,3 +41,10 @@ class PCG_XSH_RS_V0(_PCGCommon):
         """Compute output from current state."""
         state = self._state
         return ((state ^ (state >> 22)) >> (22 + (state >> 61))) & _mask
+
+    def _next_output(self):
+        """Return next output; advance the underlying LCG.
+        """
+        output = self._get_output()
+        self._advance_state()
+        return output

--- a/pcgrandom/pcg_xsl_rr_v0.py
+++ b/pcgrandom/pcg_xsl_rr_v0.py
@@ -51,6 +51,8 @@ class PCG_XSL_RR_V0(_PCGCommon):
 
     _state_bits = 128
 
+    _state_mask = 2**128 - 1
+
     _output_bits = 64
 
     # Multiplier from Table 4 of L'Ecuyer's paper.
@@ -63,3 +65,10 @@ class PCG_XSL_RR_V0(_PCGCommon):
         """Compute output from current state."""
         state = self._state
         return _rotate64(state ^ (state >> 64), state >> 122)
+
+    def _next_output(self):
+        """Return next output; advance the underlying LCG.
+        """
+        self._advance_state()
+        output = self._get_output()
+        return output

--- a/pcgrandom/test/data/generator_fingerprints.json
+++ b/pcgrandom/test/data/generator_fingerprints.json
@@ -212,23 +212,23 @@
             },
             "pickles": [
                 {
-                    "pickle": "Y3BjZ3JhbmRvbS5wY2dfeHNoX3JyX3YwClBDR19YU0hfUlJfVjAKcDAKKHRScDEKKFZwY2dyYW5kb20uUENHX1hTSF9SUl9WMApwMgooTDYzNjQxMzYyMjM4NDY3OTMwMDVMCkwxNDQyNjk1MDQwODg4OTYzNDA3TAp0cDMKTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cDQKYi4=",
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHA2CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TApOdHA3CmIu",
                     "protocol": 0
                 },
                 {
-                    "pickle": "Y3BjZ3JhbmRvbS5wY2dfeHNoX3JyX3YwClBDR19YU0hfUlJfVjAKcQApUnEBKFgXAAAAcGNncmFuZG9tLlBDR19YU0hfUlJfVjBxAihMNjM2NDEzNjIyMzg0Njc5MzAwNUwKTDE0NDI2OTUwNDA4ODg5NjM0MDdMCnRxA0wyNDU0Njg0NDYzNDg3NzkwNjQ3TApOdHEEYi4=",
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHEGTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cQdiLg==",
                     "protocol": 1
                 },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxAClScQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
                     "protocol": 2
                 },
                 {
-                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxAClScQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
                     "protocol": 3
                 },
                 {
-                    "pickle": "gASVbwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JyX3YwlIwNUENHX1hTSF9SUl9WMJSTlClSlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwlIoILX+VTC30UViKCE+BZ/d+ewUUhpSKCDcu3JmDyhAiTnSUYi4=",
+                    "pickle": "gASVbwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JyX3YwlIwNUENHX1hTSF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwlIoILX+VTC30UViKCE+BZ/d+ewUUhpSKCDcu3JmDyhAiTnSUYi4=",
                     "protocol": 4
                 }
             ],
@@ -454,23 +454,23 @@
             },
             "pickles": [
                 {
-                    "pickle": "Y3BjZ3JhbmRvbS5wY2dfeHNoX3JzX3YwClBDR19YU0hfUlNfVjAKcDAKKHRScDEKKFZwY2dyYW5kb20uUENHX1hTSF9SU19WMApwMgooTDYzNjQxMzYyMjM4NDY3OTMwMDVMCkwxNDQyNjk1MDQwODg4OTYzNDA3TAp0cDMKTDExMDM1NzAyMjM0MzQwMDY0MzY0TApOdHA0CmIu",
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHA2CkwxMTAzNTcwMjIzNDM0MDA2NDM2NEwKTnRwNwpiLg==",
                     "protocol": 0
                 },
                 {
-                    "pickle": "Y3BjZ3JhbmRvbS5wY2dfeHNoX3JzX3YwClBDR19YU0hfUlNfVjAKcQApUnEBKFgXAAAAcGNncmFuZG9tLlBDR19YU0hfUlNfVjBxAihMNjM2NDEzNjIyMzg0Njc5MzAwNUwKTDE0NDI2OTUwNDA4ODg5NjM0MDdMCnRxA0wxMTAzNTcwMjIzNDM0MDA2NDM2NEwKTnRxBGIu",
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHEGTDExMDM1NzAyMjM0MzQwMDY0MzY0TApOdHEHYi4=",
                     "protocol": 1
                 },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxAClScQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCWz80mS2sCaZAE50cQRiLg==",
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCWz80mS2sCaZAE50cQRiLg==",
                     "protocol": 2
                 },
                 {
-                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxAClScQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCWz80mS2sCaZAE50cQRiLg==",
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCWz80mS2sCaZAE50cQRiLg==",
                     "protocol": 3
                 },
                 {
-                    "pickle": "gASVcAAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JzX3YwlIwNUENHX1hTSF9SU19WMJSTlClSlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwlIoILX+VTC30UViKCE+BZ/d+ewUUhpSKCWz80mS2sCaZAE50lGIu",
+                    "pickle": "gASVcAAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JzX3YwlIwNUENHX1hTSF9SU19WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwlIoILX+VTC30UViKCE+BZ/d+ewUUhpSKCWz80mS2sCaZAE50lGIu",
                     "protocol": 4
                 }
             ],
@@ -696,23 +696,23 @@
             },
             "pickles": [
                 {
-                    "pickle": "Y3BjZ3JhbmRvbS5wY2dfeHNsX3JyX3YwClBDR19YU0xfUlJfVjAKcDAKKHRScDEKKFZwY2dyYW5kb20uUENHX1hTTF9SUl9WMApwMgooTDQ3MDI2MjQ3Njg3OTQyMTIxODQ4MTQ0MjA3NDkxODM3NTIzNTI1TApMMTE3Mzk3NTkyMTcxNTI2MTEzMjY4NTU4OTM0MTE5MDA0MjA5NDg3TAp0cDMKTDI0OTE1MzYzNTE1ODE1NDY0OTUyMjg3MjIxNTg0ODk3MjA5MzMzMUwKTnRwNApiLg==",
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHA2CkwyNDkxNTM2MzUxNTgxNTQ2NDk1MjI4NzIyMTU4NDg5NzIwOTMzMzFMCk50cDcKYi4=",
                     "protocol": 0
                 },
                 {
-                    "pickle": "Y3BjZ3JhbmRvbS5wY2dfeHNsX3JyX3YwClBDR19YU0xfUlJfVjAKcQApUnEBKFgXAAAAcGNncmFuZG9tLlBDR19YU0xfUlJfVjBxAihMNDcwMjYyNDc2ODc5NDIxMjE4NDgxNDQyMDc0OTE4Mzc1MjM1MjVMCkwxMTczOTc1OTIxNzE1MjYxMTMyNjg1NTg5MzQxMTkwMDQyMDk0ODdMCnRxA0wyNDkxNTM2MzUxNTgxNTQ2NDk1MjI4NzIyMTU4NDg5NzIwOTMzMzFMCk50cQRiLg==",
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHEGTDI0OTE1MzYzNTE1ODE1NDY0OTUyMjg3MjIxNTg0ODk3MjA5MzMzMUwKTnRxB2Iu",
                     "protocol": 1
                 },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxAClScQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihGTh/oEx4DWJXHvL7iiPnG7AE50cQRiLg==",
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihGTh/oEx4DWJXHvL7iiPnG7AE50cQRiLg==",
                     "protocol": 2
                 },
                 {
-                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxAClScQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihGTh/oEx4DWJXHvL7iiPnG7AE50cQRiLg==",
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihGTh/oEx4DWJXHvL7iiPnG7AE50cQRiLg==",
                     "protocol": 3
                 },
                 {
-                    "pickle": "gASViAAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNsX3JyX3YwlIwNUENHX1hTTF9SUl9WMJSTlClSlCiMF3BjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwlIoQRfbMn2TfhUOkXcYfBe1gI4oQT4Fn9357BRQtf5VMLfRRWIaUihGTh/oEx4DWJXHvL7iiPnG7AE50lGIu",
+                    "pickle": "gASViAAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNsX3JyX3YwlIwNUENHX1hTTF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwlIoQRfbMn2TfhUOkXcYfBe1gI4oQT4Fn9357BRQtf5VMLfRRWIaUihGTh/oEx4DWJXHvL7iiPnG7AE50lGIu",
                     "protocol": 4
                 }
             ],

--- a/pcgrandom/test/test_distributions.py
+++ b/pcgrandom/test/test_distributions.py
@@ -1,0 +1,106 @@
+# Copyright 2017 Mark Dickinson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pcgrandom import Random
+
+
+class TestDistributions(unittest.TestCase):
+    """Minimal tests for the continuous distributions in the Distributions
+    mixin class. Since the code is unaltered from that in the standard library,
+    we leave it to the standard library tests to do more effective
+    distribution-specific testing.
+
+    """
+    def setUp(self):
+        self.gen = Random(12345)
+
+    def test_uniform(self):
+        self.assertIsInstance(self.gen.uniform(1.0, 2.0), float)
+
+    def test_triangular(self):
+        self.assertIsInstance(self.gen.triangular(1.0, 2.0), float)
+        self.assertIsInstance(self.gen.triangular(1.0, 2.0, 1.3), float)
+
+        # Exercise corner cases where low == high.
+        self.assertEqual(self.gen.triangular(1.3, 1.3), 1.3)
+        self.assertEqual(self.gen.triangular(1.3, 1.3, 1.3), 1.3)
+
+        # Corner cases where mid == low or mid == high
+        self.assertIsInstance(self.gen.triangular(1.0, 2.0, 2.0), float)
+        self.assertIsInstance(self.gen.triangular(1.0, 2.0, 1.0), float)
+
+    def test_normalvariate(self):
+        sample = [self.gen.normalvariate(10.0, 5.0) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+
+    def test_lognormvariate(self):
+        sample = [self.gen.lognormvariate(10.0, 5.0) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+
+    def test_expovariate(self):
+        sample = [self.gen.expovariate(3.2) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+
+    def test_vonmisesvariate(self):
+        sample = [self.gen.vonmisesvariate(0.0, 2.0) for _ in range(20)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+
+        # Corner case where kappa is tiny.
+        sample = [self.gen.vonmisesvariate(0.0, 2e-10) for _ in range(20)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+
+    def test_gammavariate(self):
+        with self.assertRaises(ValueError):
+            self.gen.gammavariate(1.0, 0.0)
+        with self.assertRaises(ValueError):
+            self.gen.gammavariate(0.0, 1.0)
+
+        # The implementation has separate cases for alpha less than,
+        # equal to, or greater than 1. Make sure we exercise all three.
+        sample = [self.gen.gammavariate(0.7, 1.3) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+        sample = [self.gen.gammavariate(1.0, 1.3) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+        sample = [self.gen.gammavariate(1.3, 1.3) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+
+    def test_gauss(self):
+        sample = [self.gen.gauss(3.7, 1.3) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+
+    def test_betavariate(self):
+        sample = [self.gen.betavariate(0.7, 1.3) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+
+    def test_paretovariate(self):
+        sample = [self.gen.paretovariate(0.5) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
+
+    def test_weibullvariate(self):
+        sample = [self.gen.weibullvariate(700.0, 2.5) for _ in range(10)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)

--- a/pcgrandom/test/test_pcg_common.py
+++ b/pcgrandom/test/test_pcg_common.py
@@ -35,6 +35,44 @@ chisq_99percentile = {
 
 
 class TestPCGCommon(object):
+    """
+    Mixin class providing tests common to all generators in the
+    PCG family.
+    """
+    def test_creation_without_seed(self):
+        gen1 = self.gen_class()
+        gen2 = self.gen_class()
+
+        sample1 = [gen1.random() for _ in range(10)]
+        sample2 = [gen2.random() for _ in range(10)]
+
+        # Possible in theory for these two samples to be identical; vanishingly
+        # unlikely in practice.
+        self.assertNotEqual(sample1, sample2)
+
+    def test_creation_with_seed_and_sequence(self):
+        gen1 = self.gen_class(seed=12345, sequence=1)
+        gen2 = self.gen_class(12345, sequence=2)
+        # Regression test for mdickinson/pcgrandom#25.
+        gen3 = self.gen_class(12345, 1)
+        self.assertNotEqual(gen1.getstate(), gen2.getstate())
+        self.assertEqual(gen1.getrandbits(64), gen3.getrandbits(64))
+
+    def test_sequence_default(self):
+        gen = self.gen_class(seed=12345)
+        self.assertEqual(gen._increment, gen._default_increment)
+
+    def test_specification_of_multiplier(self):
+        gen = self.gen_class(seed=123, sequence=0, multiplier=5)
+        for _ in range(10):
+            old_state = gen._state
+            gen._advance_state()
+            new_state = gen._state
+            self.assertEqual(
+                new_state,
+                (old_state * 5 + gen._increment) % (2**gen._state_bits)
+            )
+
     def test_version_is_unicode(self):
         self.assertIsInstance(self.gen.VERSION, type(u''))
 
@@ -80,28 +118,6 @@ class TestPCGCommon(object):
         # up to three bad counts before failing.
         self.assertLessEqual(bad_counts, 3)
 
-    def test_creation_without_seed(self):
-        gen1 = self.gen_class()
-        gen2 = self.gen_class()
-
-        sample1 = [gen1.random() for _ in range(10)]
-        sample2 = [gen2.random() for _ in range(10)]
-
-        # Possible in theory for these two samples to be identical; vanishingly
-        # unlikely in practice.
-        self.assertNotEqual(sample1, sample2)
-
-    def test_specification_of_multiplier(self):
-        gen = self.gen_class(seed=123, sequence=0, multiplier=5)
-        for _ in range(10):
-            old_state = gen._state
-            gen._advance_state()
-            new_state = gen._state
-            self.assertEqual(
-                new_state,
-                (old_state * 5 + gen._increment) % (2**gen._state_bits)
-            )
-
     def test_state_includes_multiplier(self):
         gen = self.gen_class(seed=123, sequence=0, multiplier=5)
         state = gen.getstate()
@@ -115,10 +131,6 @@ class TestPCGCommon(object):
     def test_bad_multiplier(self):
         with self.assertRaises(ValueError):
             self.gen_class(seed=123, sequence=0, multiplier=7)
-
-    def test_sequence_default(self):
-        gen = self.gen_class(seed=12345)
-        self.assertEqual(gen._increment, gen._default_increment)
 
     def test_independent_sequences(self):
         # Crude statistical test for lack of correlation. If X and Y are

--- a/pcgrandom/test/test_pcg_common.py
+++ b/pcgrandom/test/test_pcg_common.py
@@ -20,6 +20,7 @@ from __future__ import division
 import collections
 import itertools
 import math
+import pickle
 
 # 99% values of the chi-squared statistic used in the goodness-of-fit tests
 # below, indexed by degrees of freedom. Values calculated using
@@ -36,6 +37,18 @@ chisq_99percentile = {
 class TestPCGCommon(object):
     def test_version_is_unicode(self):
         self.assertIsInstance(self.gen.VERSION, type(u''))
+
+    def test_pickleability(self):
+        for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled_gen = pickle.dumps(self.gen, protocol=protocol)
+            words = [self.gen.getrandbits(10) for _ in range(20)]
+            recovered_gen = pickle.loads(pickled_gen)
+            new_words = [recovered_gen.getrandbits(10) for _ in range(20)]
+            self.assertEqual(
+                self.gen.getstate(),
+                recovered_gen.getstate(),
+            )
+            self.assertEqual(words, new_words)
 
     def test_direct_generator_output(self):
         # Direct test of _next_output method.


### PR DESCRIPTION
We copy the distribution code from `random.Random` rather than inheriting; inheriting from `random.Random` is undesirable because it involves inheriting from `_random.Random`, which sets up the Mersenne Twister state.

Fixes #25.