### PR TITLE
Remove unnecessary aliases

### DIFF
--- a/pcgrandom/distributions.py
+++ b/pcgrandom/distributions.py
@@ -18,15 +18,12 @@ Mixin class providing various distributions.
 # The methods in this class are copied almost verbatim from Python's random
 # module.
 
-from math import (
-    acos as _acos, cos as _cos, e as _e, exp as _exp, log as _log, pi as _pi,
-    sin as _sin, sqrt as _sqrt
-)
+from math import acos, cos, e, exp, log, pi, sin, sqrt
 
-NV_MAGICCONST = 4 * _exp(-0.5)/_sqrt(2.0)
-TWOPI = 2.0*_pi
-LOG4 = _log(4.0)
-SG_MAGICCONST = 1.0 + _log(4.5)
+NV_MAGICCONST = 4 * exp(-0.5)/sqrt(2.0)
+TWOPI = 2.0*pi
+LOG4 = log(4.0)
+SG_MAGICCONST = 1.0 + log(4.5)
 
 
 class Distributions(object):
@@ -78,7 +75,7 @@ class Distributions(object):
             u2 = 1.0 - random()
             z = NV_MAGICCONST*(u1-0.5)/u2
             zz = z*z/4.0
-            if zz <= -_log(u2):
+            if zz <= -log(u2):
                 break
         return mu + z*sigma
 
@@ -90,7 +87,7 @@ class Distributions(object):
         mu can have any value, and sigma must be greater than zero.
 
         """
-        return _exp(self.normalvariate(mu, sigma))
+        return exp(self.normalvariate(mu, sigma))
 
     def expovariate(self, lambd):
         """Exponential distribution.
@@ -107,7 +104,7 @@ class Distributions(object):
 
         # we use 1-random() instead of random() to preclude the
         # possibility of taking the log of zero.
-        return -_log(1.0 - self.random())/lambd
+        return -log(1.0 - self.random())/lambd
 
     def vonmisesvariate(self, mu, kappa):
         """Circular data distribution.
@@ -134,24 +131,24 @@ class Distributions(object):
             return TWOPI * random()
 
         s = 0.5 / kappa
-        r = s + _sqrt(1.0 + s * s)
+        r = s + sqrt(1.0 + s * s)
 
         while 1:
             u1 = random()
-            z = _cos(_pi * u1)
+            z = cos(pi * u1)
 
             d = z / (r + z)
             u2 = random()
-            if u2 < 1.0 - d * d or u2 <= (1.0 - d) * _exp(d):
+            if u2 < 1.0 - d * d or u2 <= (1.0 - d) * exp(d):
                 break
 
         q = 1.0 / r
         f = (q + z) / (1.0 + q * z)
         u3 = random()
         if u3 > 0.5:
-            theta = (mu + _acos(f)) % TWOPI
+            theta = (mu + acos(f)) % TWOPI
         else:
-            theta = (mu - _acos(f)) % TWOPI
+            theta = (mu - acos(f)) % TWOPI
 
         return theta
 
@@ -182,7 +179,7 @@ class Distributions(object):
             # variables with non-integral shape parameters",
             # Applied Statistics, (1977), 26, No. 1, p71-74
 
-            ainv = _sqrt(2.0 * alpha - 1.0)
+            ainv = sqrt(2.0 * alpha - 1.0)
             bbb = alpha - LOG4
             ccc = alpha + ainv
 
@@ -191,11 +188,11 @@ class Distributions(object):
                 if not 1e-7 < u1 < .9999999:
                     continue
                 u2 = 1.0 - random()
-                v = _log(u1/(1.0-u1))/ainv
-                x = alpha*_exp(v)
+                v = log(u1/(1.0-u1))/ainv
+                x = alpha*exp(v)
                 z = u1*u1*u2
                 r = bbb+ccc*v-x
-                if r + SG_MAGICCONST - 4.5*z >= 0.0 or r >= _log(z):
+                if r + SG_MAGICCONST - 4.5*z >= 0.0 or r >= log(z):
                     return x * beta
 
         elif alpha == 1.0:
@@ -203,7 +200,7 @@ class Distributions(object):
             u = random()
             while u <= 1e-7:
                 u = random()
-            return -_log(u) * beta
+            return -log(u) * beta
 
         else:   # alpha is between 0 and 1 (exclusive)
 
@@ -211,17 +208,17 @@ class Distributions(object):
 
             while 1:
                 u = random()
-                b = (_e + alpha)/_e
+                b = (e + alpha)/e
                 p = b*u
                 if p <= 1.0:
                     x = p ** (1.0/alpha)
                 else:
-                    x = -_log((b-p)/alpha)
+                    x = -log((b-p)/alpha)
                 u1 = random()
                 if p > 1.0:
                     if u1 <= x ** (alpha - 1.0):
                         break
-                elif u1 <= _exp(-x):
+                elif u1 <= exp(-x):
                     break
             return x * beta
 
@@ -258,9 +255,9 @@ class Distributions(object):
         self.gauss_next = None
         if z is None:
             x2pi = random() * TWOPI
-            g2rad = _sqrt(-2.0 * _log(1.0 - random()))
-            z = _cos(x2pi) * g2rad
-            self.gauss_next = _sin(x2pi) * g2rad
+            g2rad = sqrt(-2.0 * log(1.0 - random()))
+            z = cos(x2pi) * g2rad
+            self.gauss_next = sin(x2pi) * g2rad
 
         return mu + z*sigma
 
@@ -296,4 +293,4 @@ class Distributions(object):
         # Jain, pg. 499; bug fix courtesy Bill Arms
 
         u = 1.0 - self.random()
-        return alpha * (-_log(u)) ** (1.0/beta)
+        return alpha * (-log(u)) ** (1.0/beta)

--- a/pcgrandom/pcg_common.py
+++ b/pcgrandom/pcg_common.py
@@ -45,7 +45,7 @@ def seed_from_system_entropy(bits):
         Integer seed in the range 0 <= seed < 2**bits.
     """
     numbytes, excess = -(-bits // 8), -bits % 8
-    seed = _int.from_bytes(_os.urandom(numbytes), byteorder="big")
+    seed = _int.from_bytes(os.urandom(numbytes), byteorder="big")
     return seed >> excess
 
 
@@ -69,7 +69,7 @@ def seed_from_object(obj, bits):
     """
     # From an integer-like.
     try:
-        obj_as_integer = _operator.index(obj)
+        obj_as_integer = operator.index(obj)
     except TypeError:
         pass
     else:

--- a/pcgrandom/pcg_common.py
+++ b/pcgrandom/pcg_common.py
@@ -17,12 +17,13 @@ Common base class for the various PCG implementations.
 """
 from __future__ import division
 
-import bisect as _bisect
-import collections as _collections
-import operator as _operator
-import os as _os
+import bisect
+import collections
+import operator
+import os
 
-from builtins import int as _int, range as _range
+# Python 2 compatibility.
+from builtins import int as _int, range
 
 from pcgrandom.distributions import Distributions
 
@@ -34,12 +35,12 @@ class PCGCommon(Distributions):
     def __init__(self, seed=None, sequence=None, multiplier=None):
         if multiplier is None:
             multiplier = self._default_multiplier
-        multiplier = _operator.index(multiplier) & self._state_mask
+        multiplier = operator.index(multiplier) & self._state_mask
 
         if sequence is None:
             increment = self._default_increment
         else:
-            sequence = _operator.index(sequence) & self._state_mask
+            sequence = operator.index(sequence) & self._state_mask
             increment = 2 * sequence + 1 & self._state_mask
 
         # The multiplier must be congruent to 1 modulo 4 to achieve
@@ -62,9 +63,9 @@ class PCGCommon(Distributions):
         """
         if seed is None:
             nbytes = self._state_bits // 8
-            seed = _int.from_bytes(_os.urandom(nbytes), byteorder="little")
+            seed = _int.from_bytes(os.urandom(nbytes), byteorder="little")
         else:
-            seed = _operator.index(seed)
+            seed = operator.index(seed)
 
         self._set_state_from_seed(seed)
         self.gauss_next = None
@@ -96,7 +97,7 @@ class PCGCommon(Distributions):
         k : nonnegative integer
 
         """
-        k = _operator.index(k)
+        k = operator.index(k)
         if k < 0:
             raise ValueError("Number of bits should be nonnegative.")
 
@@ -104,7 +105,7 @@ class PCGCommon(Distributions):
 
         numwords, excess_bits = -(-k // output_bits), -k % output_bits
         acc = 0
-        for _ in _range(numwords):
+        for _ in range(numwords):
             acc = acc << output_bits | self._next_output()
         # int call converts small longs to ints on Python 2.
         return int(acc >> excess_bits)
@@ -132,7 +133,7 @@ class PCGCommon(Distributions):
         # Reimplemented from the base class to ensure reproducibility
         # across Python versions. The code below is adapted from that
         # in Python 3.6.
-        istart = _operator.index(start)
+        istart = operator.index(start)
         if stop is None:
             if istart > 0:
                 return self._randbelow(istart)
@@ -140,7 +141,7 @@ class PCGCommon(Distributions):
                 raise ValueError(
                     "Empty range for randrange({0}).".format(istart))
 
-        istop = _operator.index(stop)
+        istop = operator.index(stop)
         width = istop - istart
         if step is None:
             if width > 0:
@@ -150,7 +151,7 @@ class PCGCommon(Distributions):
                     "Empty range for randrange({0}, {1}).".format(
                         istart, istop))
 
-        istep = _operator.index(step)
+        istep = operator.index(step)
         if istep == 0:
             raise ValueError("Zero step for randrange().")
         n = -(-width // istep)
@@ -164,8 +165,8 @@ class PCGCommon(Distributions):
     def randint(self, a, b):
         """Return random integer in range [a, b], including both end points.
         """
-        istart = _operator.index(a)
-        width = _operator.index(b) - istart + 1
+        istart = operator.index(a)
+        width = operator.index(b) - istart + 1
         if width > 0:
             return istart + self._randbelow(width)
         else:
@@ -224,7 +225,7 @@ class PCGCommon(Distributions):
     def shuffle(self, x):
         """Shuffle list x in place, and return None."""
         n = len(x)
-        for i in reversed(_range(n)):
+        for i in reversed(range(n)):
             j = i + self._randbelow(n - i)
             if j > i:
                 x[i], x[j] = x[j], x[i]
@@ -246,9 +247,9 @@ class PCGCommon(Distributions):
         This is especially fast and space efficient for sampling from a
         large population:   sample(range(10000000), 60)
         """
-        if isinstance(population, _collections.Set):
+        if isinstance(population, collections.Set):
             population = tuple(population)
-        if not isinstance(population, _collections.Sequence):
+        if not isinstance(population, collections.Sequence):
             raise TypeError(
                 "Population must be a sequence or set.  "
                 "For dicts, use list(d).")
@@ -262,7 +263,7 @@ class PCGCommon(Distributions):
         # python-list dated May 28th 2010, entitled "A Friday Python
         # Programming Pearl: random sampling".
         d = {}
-        for i in reversed(_range(k)):
+        for i in reversed(range(k)):
             j = i + self._randbelow(n - i)
             if j in d:
                 d[i] = d[j]
@@ -289,7 +290,7 @@ class PCGCommon(Distributions):
             if weights is None:
                 if len(population) == 0:
                     raise IndexError("Cannot choose from an empty population.")
-                return [self.choice(population) for _ in _range(k)]
+                return [self.choice(population) for _ in range(k)]
             cum_weights, acc = [], 0
             for weight in weights:
                 acc += weight
@@ -315,6 +316,6 @@ class PCGCommon(Distributions):
         # less than 1.0, and bisectors[-1] == 1.0, so the result of the bisect
         # call should always be strictly smaller than len(population).
         return [
-            population[_bisect.bisect(bisectors, self.random())]
+            population[bisect.bisect(bisectors, self.random())]
             for _ in range(k)
         ]

--- a/pcgrandom/pcg_xsh_rr_v0.py
+++ b/pcgrandom/pcg_xsh_rr_v0.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pcgrandom.pcg_common import PCGCommon as _PCGCommon
+from pcgrandom.pcg_common import PCGCommon
 
 
 def _rotate32(v, r, _multiplier=2**32 + 1, _mask=2**32 - 1):
@@ -39,7 +39,7 @@ def _rotate32(v, r, _multiplier=2**32 + 1, _mask=2**32 - 1):
     return (v & _mask) * _multiplier >> r & _mask
 
 
-class PCG_XSH_RR_V0(_PCGCommon):
+class PCG_XSH_RR_V0(PCGCommon):
     """
     Random subclass based on Melissa O'Neill's PCG family.
 

--- a/pcgrandom/pcg_xsh_rs_v0.py
+++ b/pcgrandom/pcg_xsh_rs_v0.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pcgrandom.pcg_common import PCGCommon as _PCGCommon
+from pcgrandom.pcg_common import PCGCommon
 
 
-class PCG_XSH_RS_V0(_PCGCommon):
+class PCG_XSH_RS_V0(PCGCommon):
     """
     Random subclass based on Melissa O'Neill's PCG family.
 

--- a/pcgrandom/pcg_xsl_rr_v0.py
+++ b/pcgrandom/pcg_xsl_rr_v0.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pcgrandom.pcg_common import PCGCommon as _PCGCommon
+from pcgrandom.pcg_common import PCGCommon
 
 
 def _rotate64(v, r, _multiplier=2**64 + 1, _mask=2**64 - 1):
@@ -39,7 +39,7 @@ def _rotate64(v, r, _multiplier=2**64 + 1, _mask=2**64 - 1):
     return (v & _mask) * _multiplier >> r & _mask
 
 
-class PCG_XSL_RR_V0(_PCGCommon):
+class PCG_XSL_RR_V0(PCGCommon):
     """
     Random subclass based on Melissa O'Neill's PCG family.
 


### PR DESCRIPTION
The import aliases are unnecessary. The only place we need to be careful is in the top-level `__init__` module: we want to be sure that a `from pcgrandom import *` only picks up the intended things.