### PR TITLE
Refactor pickle testing code

### DIFF
--- a/pcgrandom/__init__.py
+++ b/pcgrandom/__init__.py
@@ -23,6 +23,9 @@ __all__ = [
     # Generator synonyms
     "PCG32", "PCG64", "Random",
 
+    # List of all generators (not including synonyms).
+    "pcg_generators",
+
     # Methods related to the internal state.
     "getstate", "jumpahead", "seed", "setstate",
 
@@ -38,6 +41,9 @@ __all__ = [
     "vonmisesvariate", "weibullvariate",
 
 ]
+
+# List of all available generators; mostly used in testing.
+pcg_generators = [PCG_XSH_RR_V0, PCG_XSH_RS_V0, PCG_XSL_RR_V0]
 
 # Allow users to do 'from pcgrandom import Random', to mimic standard library
 # 'random' module. Note that this may change with releases, so if

--- a/pcgrandom/pcg_common.py
+++ b/pcgrandom/pcg_common.py
@@ -79,7 +79,7 @@ def seed_from_object(obj, bits):
 
     # For a Unicode or byte string.
     if isinstance(obj, unicode):
-        obj = obj.encode('utf8')
+        obj = obj.encode('utf-8')
 
     if isinstance(obj, bytes):
         obj_hash = hashlib.sha512(obj).digest()

--- a/pcgrandom/test/data/pickles-pypy2.json
+++ b/pcgrandom/test/data/pickles-pypy2.json
@@ -150,5 +150,15 @@
                 null
             ]
         }
-    ]
+    ], 
+    "platform": {
+        "architecture": [
+            "64bit", 
+            ""
+        ], 
+        "implementation": "PyPy", 
+        "platform": "Darwin-14.5.0-x86_64-i386-64bit", 
+        "revision": "", 
+        "version": "2.7.13"
+    }
 }

--- a/pcgrandom/test/data/pickles-pypy2.json
+++ b/pcgrandom/test/data/pickles-pypy2.json
@@ -1,0 +1,154 @@
+{
+    "generators": [
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApJMTQ0MjY5NTA0MDg4ODk2MzQwNwp0cDYKTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cDcKYi4=", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApJMTQ0MjY5NTA0MDg4ODk2MzQwNwp0cQZMMjQ1NDY4NDQ2MzQ4Nzc5MDY0N0wKTnRxB2Iu", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWEkxNDQyNjk1MDQwODg4OTYzNDA3CoZxA4oINy7cmYPKECJOdHEEYi4=", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSH_RR_V0", 
+                [
+                    6364136223846793005, 
+                    1442695040888963407
+                ], 
+                2454684463487790647, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApJMTQ0MjY5NTA0MDg4ODk2MzQwNwp0cDYKTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cDcKYi4=", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApJMTQ0MjY5NTA0MDg4ODk2MzQwNwp0cQZMMjQ1NDY4NDQ2MzQ4Nzc5MDY0N0wKTnRxB2Iu", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWEkxNDQyNjk1MDQwODg4OTYzNDA3CoZxA4oINy7cmYPKECJOdHEEYi4=", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSH_RS_V0", 
+                [
+                    6364136223846793005, 
+                    1442695040888963407
+                ], 
+                2454684463487790647, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHA2CkwxMTM2MDQ3NTUzOTYxMjA4Mjc2NDQ4NzI4NzM5MjUzMjgxNzc5MTFMCk50cDcKYi4=", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHEGTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKTnRxB2Iu", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihD3ClM7eiXRzjQa/N3iendVTnRxBGIu", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSL_RR_V0", 
+                [
+                    47026247687942121848144207491837523525, 
+                    117397592171526113268558934119004209487
+                ], 
+                113604755396120827644872873925328177911, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRwNgpMODI0NjU3MTMxMTY4MjMyNjk1TApOdHA3CmIu", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRxBkw4MjQ2NTcxMzExNjgyMzI2OTVMCk50cQdiLg==", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoBRYZxA4oI93TGpErFcQtOdHEEYi4=", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSH_RR_V0", 
+                [
+                    6364136223846793005, 
+                    69
+                ], 
+                824657131168232695, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRwNgpMODI0NjU3MTMxMTY4MjMyNjk1TApOdHA3CmIu", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRxBkw4MjQ2NTcxMzExNjgyMzI2OTVMCk50cQdiLg==", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoBRYZxA4oI93TGpErFcQtOdHEEYi4=", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSH_RS_V0", 
+                [
+                    6364136223846793005, 
+                    69
+                ], 
+                824657131168232695, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TAp0cDYKTDMwNzA0ODgzMjQwOTE1MTgzMzg3OTUwNjAxNTE1NDM5OTk3MjQ1NUwKTnRwNwpiLg==", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TAp0cQZMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TApOdHEHYi4=", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjigFFhnEDihFnjPXep0rlEXQm9hk+dP/mAE50cQRiLg==", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSL_RR_V0", 
+                [
+                    47026247687942121848144207491837523525, 
+                    69
+                ], 
+                307048832409151833879506015154399972455, 
+                null
+            ]
+        }
+    ]
+}

--- a/pcgrandom/test/data/pickles-pypy3.json
+++ b/pcgrandom/test/data/pickles-pypy3.json
@@ -1,0 +1,202 @@
+{
+    "generators": [
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHA2CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TApOdHA3CmIu",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHEGTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cQdiLg==",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVbwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JyX3YwlIwNUENHX1hTSF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwlIoILX+VTC30UViKCE+BZ/d+ewUUhpSKCDcu3JmDyhAiTnSUYi4=",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSH_RR_V0",
+                [
+                    6364136223846793005,
+                    1442695040888963407
+                ],
+                2454684463487790647,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHA2CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TApOdHA3CmIu",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHEGTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cQdiLg==",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVbwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JzX3YwlIwNUENHX1hTSF9SU19WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwlIoILX+VTC30UViKCE+BZ/d+ewUUhpSKCDcu3JmDyhAiTnSUYi4=",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSH_RS_V0",
+                [
+                    6364136223846793005,
+                    1442695040888963407
+                ],
+                2454684463487790647,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHA2CkwxMTM2MDQ3NTUzOTYxMjA4Mjc2NDQ4NzI4NzM5MjUzMjgxNzc5MTFMCk50cDcKYi4=",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHEGTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKTnRxB2Iu",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihD3ClM7eiXRzjQa/N3iendVTnRxBGIu",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihD3ClM7eiXRzjQa/N3iendVTnRxBGIu",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVhwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNsX3JyX3YwlIwNUENHX1hTTF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwlIoQRfbMn2TfhUOkXcYfBe1gI4oQT4Fn9357BRQtf5VMLfRRWIaUihD3ClM7eiXRzjQa/N3iendVTnSUYi4=",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSL_RR_V0",
+                [
+                    47026247687942121848144207491837523525,
+                    117397592171526113268558934119004209487
+                ],
+                113604755396120827644872873925328177911,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRwNgpMODI0NjU3MTMxMTY4MjMyNjk1TApOdHA3CmIu",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApLRXRxBkw4MjQ2NTcxMzExNjgyMzI2OTVMCk50cQdiLg==",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWEtFhnEDigj3dMakSsVxC050cQRiLg==",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWEtFhnEDigj3dMakSsVxC050cQRiLg==",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVZwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JyX3YwlIwNUENHX1hTSF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwlIoILX+VTC30UVhLRYaUigj3dMakSsVxC050lGIu",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSH_RR_V0",
+                [
+                    6364136223846793005,
+                    69
+                ],
+                824657131168232695,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRwNgpMODI0NjU3MTMxMTY4MjMyNjk1TApOdHA3CmIu",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApLRXRxBkw4MjQ2NTcxMzExNjgyMzI2OTVMCk50cQdiLg==",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWEtFhnEDigj3dMakSsVxC050cQRiLg==",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWEtFhnEDigj3dMakSsVxC050cQRiLg==",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVZwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JzX3YwlIwNUENHX1hTSF9SU19WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwlIoILX+VTC30UVhLRYaUigj3dMakSsVxC050lGIu",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSH_RS_V0",
+                [
+                    6364136223846793005,
+                    69
+                ],
+                824657131168232695,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TAp0cDYKTDMwNzA0ODgzMjQwOTE1MTgzMzg3OTUwNjAxNTE1NDM5OTk3MjQ1NUwKTnRwNwpiLg==",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKS0V0cQZMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TApOdHEHYi4=",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjS0WGcQOKEWeM9d6nSuURdCb2GT50/+YATnRxBGIu",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjS0WGcQOKEWeM9d6nSuURdCb2GT50/+YATnRxBGIu",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVeAAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNsX3JyX3YwlIwNUENHX1hTTF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwlIoQRfbMn2TfhUOkXcYfBe1gI0tFhpSKEWeM9d6nSuURdCb2GT50/+YATnSUYi4=",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSL_RR_V0",
+                [
+                    47026247687942121848144207491837523525,
+                    69
+                ],
+                307048832409151833879506015154399972455,
+                null
+            ]
+        }
+    ]
+}

--- a/pcgrandom/test/data/pickles-pypy3.json
+++ b/pcgrandom/test/data/pickles-pypy3.json
@@ -198,5 +198,15 @@
                 null
             ]
         }
-    ]
+    ],
+    "platform": {
+        "architecture": [
+            "64bit",
+            ""
+        ],
+        "implementation": "PyPy",
+        "platform": "Darwin-14.5.0-x86_64-i386-64bit",
+        "revision": "a37ecfe5f142bc971a86d17305cc5d1d70abec64",
+        "version": "3.5.3"
+    }
 }

--- a/pcgrandom/test/data/pickles-python2.json
+++ b/pcgrandom/test/data/pickles-python2.json
@@ -150,5 +150,15 @@
                 null
             ]
         }
-    ]
+    ], 
+    "platform": {
+        "architecture": [
+            "64bit", 
+            ""
+        ], 
+        "implementation": "CPython", 
+        "platform": "Darwin-14.5.0-x86_64-i386-64bit", 
+        "revision": "", 
+        "version": "2.7.13"
+    }
 }

--- a/pcgrandom/test/data/pickles-python2.json
+++ b/pcgrandom/test/data/pickles-python2.json
@@ -1,0 +1,154 @@
+{
+    "generators": [
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApJMTQ0MjY5NTA0MDg4ODk2MzQwNwp0cDYKTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cDcKYi4=", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApJMTQ0MjY5NTA0MDg4ODk2MzQwNwp0cQZMMjQ1NDY4NDQ2MzQ4Nzc5MDY0N0wKTnRxB2Iu", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWEkxNDQyNjk1MDQwODg4OTYzNDA3CoZxA4oINy7cmYPKECJOdHEEYi4=", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSH_RR_V0", 
+                [
+                    6364136223846793005, 
+                    1442695040888963407
+                ], 
+                2454684463487790647, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApJMTQ0MjY5NTA0MDg4ODk2MzQwNwp0cDYKTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cDcKYi4=", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApJMTQ0MjY5NTA0MDg4ODk2MzQwNwp0cQZMMjQ1NDY4NDQ2MzQ4Nzc5MDY0N0wKTnRxB2Iu", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWEkxNDQyNjk1MDQwODg4OTYzNDA3CoZxA4oINy7cmYPKECJOdHEEYi4=", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSH_RS_V0", 
+                [
+                    6364136223846793005, 
+                    1442695040888963407
+                ], 
+                2454684463487790647, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHA2CkwxMTM2MDQ3NTUzOTYxMjA4Mjc2NDQ4NzI4NzM5MjUzMjgxNzc5MTFMCk50cDcKYi4=", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHEGTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKTnRxB2Iu", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihD3ClM7eiXRzjQa/N3iendVTnRxBGIu", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSL_RR_V0", 
+                [
+                    47026247687942121848144207491837523525, 
+                    117397592171526113268558934119004209487
+                ], 
+                113604755396120827644872873925328177911, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRwNgpMODI0NjU3MTMxMTY4MjMyNjk1TApOdHA3CmIu", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRxBkw4MjQ2NTcxMzExNjgyMzI2OTVMCk50cQdiLg==", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoBRYZxA4oI93TGpErFcQtOdHEEYi4=", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSH_RR_V0", 
+                [
+                    6364136223846793005, 
+                    69
+                ], 
+                824657131168232695, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRwNgpMODI0NjU3MTMxMTY4MjMyNjk1TApOdHA3CmIu", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRxBkw4MjQ2NTcxMzExNjgyMzI2OTVMCk50cQdiLg==", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoBRYZxA4oI93TGpErFcQtOdHEEYi4=", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSH_RS_V0", 
+                [
+                    6364136223846793005, 
+                    69
+                ], 
+                824657131168232695, 
+                null
+            ]
+        }, 
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TAp0cDYKTDMwNzA0ODgzMjQwOTE1MTgzMzg3OTUwNjAxNTE1NDM5OTk3MjQ1NUwKTnRwNwpiLg==", 
+                    "protocol": 0
+                }, 
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TAp0cQZMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TApOdHEHYi4=", 
+                    "protocol": 1
+                }, 
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjigFFhnEDihFnjPXep0rlEXQm9hk+dP/mAE50cQRiLg==", 
+                    "protocol": 2
+                }
+            ], 
+            "state": [
+                "pcgrandom.PCG_XSL_RR_V0", 
+                [
+                    47026247687942121848144207491837523525, 
+                    69
+                ], 
+                307048832409151833879506015154399972455, 
+                null
+            ]
+        }
+    ]
+}

--- a/pcgrandom/test/data/pickles-python3.json
+++ b/pcgrandom/test/data/pickles-python3.json
@@ -198,5 +198,15 @@
                 null
             ]
         }
-    ]
+    ],
+    "platform": {
+        "architecture": [
+            "64bit",
+            ""
+        ],
+        "implementation": "CPython",
+        "platform": "Darwin-14.5.0-x86_64-i386-64bit",
+        "revision": "",
+        "version": "3.6.2"
+    }
 }

--- a/pcgrandom/test/data/pickles-python3.json
+++ b/pcgrandom/test/data/pickles-python3.json
@@ -1,0 +1,202 @@
+{
+    "generators": [
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHA2CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TApOdHA3CmIu",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHEGTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cQdiLg==",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVbwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JyX3YwlIwNUENHX1hTSF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwlIoILX+VTC30UViKCE+BZ/d+ewUUhpSKCDcu3JmDyhAiTnSUYi4=",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSH_RR_V0",
+                [
+                    6364136223846793005,
+                    1442695040888963407
+                ],
+                2454684463487790647,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHA2CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TApOdHA3CmIu",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMMTQ0MjY5NTA0MDg4ODk2MzQwN0wKdHEGTDI0NTQ2ODQ0NjM0ODc3OTA2NDdMCk50cQdiLg==",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWIoIT4Fn9357BRSGcQOKCDcu3JmDyhAiTnRxBGIu",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVbwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JzX3YwlIwNUENHX1hTSF9SU19WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwlIoILX+VTC30UViKCE+BZ/d+ewUUhpSKCDcu3JmDyhAiTnSUYi4=",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSH_RS_V0",
+                [
+                    6364136223846793005,
+                    1442695040888963407
+                ],
+                2454684463487790647,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHA2CkwxMTM2MDQ3NTUzOTYxMjA4Mjc2NDQ4NzI4NzM5MjUzMjgxNzc5MTFMCk50cDcKYi4=",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKdHEGTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKTnRxB2Iu",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihD3ClM7eiXRzjQa/N3iendVTnRxBGIu",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjihBPgWf3fnsFFC1/lUwt9FFYhnEDihD3ClM7eiXRzjQa/N3iendVTnRxBGIu",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVhwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNsX3JyX3YwlIwNUENHX1hTTF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwlIoQRfbMn2TfhUOkXcYfBe1gI4oQT4Fn9357BRQtf5VMLfRRWIaUihD3ClM7eiXRzjQa/N3iendVTnSUYi4=",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSL_RR_V0",
+                [
+                    47026247687942121848144207491837523525,
+                    117397592171526113268558934119004209487
+                ],
+                113604755396120827644872873925328177911,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRwNgpMODI0NjU3MTMxMTY4MjMyNjk1TApOdHA3CmIu",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApLRXRxBkw4MjQ2NTcxMzExNjgyMzI2OTVMCk50cQdiLg==",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWEtFhnEDigj3dMakSsVxC050cQRiLg==",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHECiggtf5VMLfRRWEtFhnEDigj3dMakSsVxC050cQRiLg==",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVZwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JyX3YwlIwNUENHX1hTSF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwlIoILX+VTC30UVhLRYaUigj3dMakSsVxC050lGIu",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSH_RR_V0",
+                [
+                    6364136223846793005,
+                    69
+                ],
+                824657131168232695,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApMNjlMCnRwNgpMODI0NjU3MTMxMTY4MjMyNjk1TApOdHA3CmIu",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEw2MzY0MTM2MjIzODQ2NzkzMDA1TApLRXRxBkw4MjQ2NTcxMzExNjgyMzI2OTVMCk50cQdiLg==",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWEtFhnEDigj3dMakSsVxC050cQRiLg==",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHECiggtf5VMLfRRWEtFhnEDigj3dMakSsVxC050cQRiLg==",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVZwAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNoX3JzX3YwlIwNUENHX1hTSF9SU19WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwlIoILX+VTC30UVhLRYaUigj3dMakSsVxC050lGIu",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSH_RS_V0",
+                [
+                    6364136223846793005,
+                    69
+                ],
+                824657131168232695,
+                null
+            ]
+        },
+        {
+            "pickles": [
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TAp0cDYKTDMwNzA0ODgzMjQwOTE1MTgzMzg3OTUwNjAxNTE1NDM5OTk3MjQ1NUwKTnRwNwpiLg==",
+                    "protocol": 0
+                },
+                {
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKS0V0cQZMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TApOdHEHYi4=",
+                    "protocol": 1
+                },
+                {
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjS0WGcQOKEWeM9d6nSuURdCb2GT50/+YATnRxBGIu",
+                    "protocol": 2
+                },
+                {
+                    "pickle": "gANjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQEoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHECihBF9syfZN+FQ6Rdxh8F7WAjS0WGcQOKEWeM9d6nSuURdCb2GT50/+YATnRxBGIu",
+                    "protocol": 3
+                },
+                {
+                    "pickle": "gASVeAAAAAAAAACMF3BjZ3JhbmRvbS5wY2dfeHNsX3JyX3YwlIwNUENHX1hTTF9SUl9WMJSTlCmBlCiMF3BjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwlIoQRfbMn2TfhUOkXcYfBe1gI0tFhpSKEWeM9d6nSuURdCb2GT50/+YATnSUYi4=",
+                    "protocol": 4
+                }
+            ],
+            "state": [
+                "pcgrandom.PCG_XSL_RR_V0",
+                [
+                    47026247687942121848144207491837523525,
+                    69
+                ],
+                307048832409151833879506015154399972455,
+                null
+            ]
+        }
+    ]
+}

--- a/pcgrandom/test/test_pickle_data.py
+++ b/pcgrandom/test/test_pickle_data.py
@@ -1,0 +1,60 @@
+"""
+Test that we can unpickle a generator that was pickled on a possibly
+different Python version.
+"""
+
+# XXX Put python version into pickle data file.
+
+import base64
+import json
+import pickle
+import pkgutil
+import unittest
+
+
+DATA_FILES = [
+    'pickles-python2.json',
+    'pickles-python3.json',
+    'pickles-pypy2.json',
+    'pickles-pypy3.json',
+]
+
+
+def load_pickle_data(filename):
+    """
+    Load pickle data from the given file.
+    """
+    raw_data = pkgutil.get_data('pcgrandom.test', 'data/{}'.format(filename))
+    return json.loads(raw_data.decode('utf-8'))
+
+
+def string_to_bytes(s):
+    """Reverse transformation for bytes_to_string.
+    """
+    return base64.b64decode(s.encode('ascii'))
+
+
+def tuple_to_list(l):
+    """Recursive tuple to list conversion."""
+    if isinstance(l, tuple):
+        return list(map(tuple_to_list, l))
+    else:
+        return l
+
+
+class TestUnpickling(unittest.TestCase):
+    def test_unpickling(self):
+        for filename in DATA_FILES:
+            all_pickle_data = load_pickle_data(filename)
+            for generator_data in all_pickle_data['generators']:
+                state = generator_data['state']
+                for pickle_data in generator_data['pickles']:
+                    protocol = pickle_data['protocol']
+                    pickled_generator = string_to_bytes(pickle_data['pickle'])
+                    if protocol > pickle.HIGHEST_PROTOCOL:
+                        continue
+                    generator = pickle.loads(pickled_generator)
+                    self.assertEqual(
+                        tuple_to_list(generator.getstate()),
+                        state,
+                    )

--- a/pcgrandom/test/test_pickle_data.py
+++ b/pcgrandom/test/test_pickle_data.py
@@ -20,28 +20,31 @@ import pickle
 import unittest
 
 from pcgrandom.test.write_pickle_data import (
+    AllGeneratorsPickles,
     pickle_filenames,
-    read_pickle_info,
 )
 
 
 class TestUnpickling(unittest.TestCase):
     def test_unpickling(self):
         for version, filename in pickle_filenames().items():
-            all_pickle_data = read_pickle_info(filename)
-            for generator_data in all_pickle_data['generators']:
-                expected_state = generator_data['state']
+            all_pickle_data = AllGeneratorsPickles.load(filename)
+            self.check_pickle_data(version, all_pickle_data)
 
-                for pickle_data in generator_data['pickles']:
-                    protocol = pickle_data['protocol']
-                    pickled_generator = pickle_data['pickle']
-                    if protocol > pickle.HIGHEST_PROTOCOL:
-                        continue
-                    self.assertEqual(
-                        pickle.loads(pickled_generator).getstate(),
-                        expected_state,
-                        msg=(
-                            "Unpickling failed for version {}, "
-                            "protocol {}".format(version, protocol)
-                        ),
-                    )
+    def check_pickle_data(self, version, all_pickle_data):
+        for generator_data in all_pickle_data.generators:
+            expected_state = generator_data.state
+
+            for pickle_data in generator_data.pickles:
+                protocol = pickle_data.protocol
+                pickled_generator = pickle_data.data
+                if protocol > pickle.HIGHEST_PROTOCOL:
+                    continue
+                self.assertEqual(
+                    pickle.loads(pickled_generator).getstate(),
+                    expected_state,
+                    msg=(
+                        "Unpickling failed for version {}, "
+                        "protocol {}".format(version, protocol)
+                    ),
+                )

--- a/pcgrandom/test/test_pickle_data.py
+++ b/pcgrandom/test/test_pickle_data.py
@@ -11,13 +11,7 @@ import pickle
 import pkgutil
 import unittest
 
-
-DATA_FILES = [
-    'pickles-python2.json',
-    'pickles-python3.json',
-    'pickles-pypy2.json',
-    'pickles-pypy3.json',
-]
+from pcgrandom.test.write_pickle_data import json_filenames
 
 
 def load_pickle_data(filename):
@@ -44,7 +38,7 @@ def tuple_to_list(l):
 
 class TestUnpickling(unittest.TestCase):
     def test_unpickling(self):
-        for filename in DATA_FILES:
+        for version, filename in json_filenames().items():
             all_pickle_data = load_pickle_data(filename)
             for generator_data in all_pickle_data['generators']:
                 state = generator_data['state']

--- a/pcgrandom/test/test_pickle_data.py
+++ b/pcgrandom/test/test_pickle_data.py
@@ -16,20 +16,38 @@
 Test that we can unpickle a generator that was pickled on a possibly
 different Python version.
 """
+import os
 import pickle
+import shutil
+import tempfile
 import unittest
 
+from pcgrandom.test.testing_utils import args_in_sys_argv
 from pcgrandom.test.write_pickle_data import (
     AllGeneratorsPickles,
     pickle_filenames,
+    write_pickle_data,
 )
 
 
 class TestUnpickling(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
     def test_unpickling(self):
         for version, filename in pickle_filenames().items():
             all_pickle_data = AllGeneratorsPickles.load(filename)
             self.check_pickle_data(version, all_pickle_data)
+
+    def test_write_pickle_data(self):
+        json_filename = os.path.join(self.tempdir, 'test_pickle_data.json')
+        self.assertFalse(os.path.exists(json_filename))
+        with args_in_sys_argv([json_filename]):
+            write_pickle_data()
+        self.assertTrue(os.path.exists(json_filename))
 
     def check_pickle_data(self, version, all_pickle_data):
         for generator_data in all_pickle_data.generators:

--- a/pcgrandom/test/test_regenerate_reproducibility_data.py
+++ b/pcgrandom/test/test_regenerate_reproducibility_data.py
@@ -16,7 +16,6 @@ import contextlib
 import json
 import os
 import shutil
-import sys
 import tempfile
 import unittest
 
@@ -24,6 +23,7 @@ from pcgrandom.test.regenerate_reproducibility_data import (
     DEFAULT_REPRODUCIBILITY_FILENAME,
     regenerate_data_main,
 )
+from pcgrandom.test.testing_utils import args_in_sys_argv
 
 
 @contextlib.contextmanager
@@ -37,19 +37,6 @@ def cwd(dir):
         yield
     finally:
         os.chdir(old_cwd)
-
-
-@contextlib.contextmanager
-def args_in_sys_argv(args):
-    """
-    Temporarily change sys.argv to something of the form [prog_name, args].
-    """
-    old_sys_argv = sys.argv
-    sys.argv = sys.argv[:1] + args
-    try:
-        yield
-    finally:
-        sys.argv = old_sys_argv
 
 
 class TestRegenerateReproducibilityData(unittest.TestCase):

--- a/pcgrandom/test/testing_utils.py
+++ b/pcgrandom/test/testing_utils.py
@@ -1,0 +1,29 @@
+# Copyright 2017 Mark Dickinson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import sys
+
+
+@contextlib.contextmanager
+def args_in_sys_argv(args):
+    """
+    Temporarily change sys.argv to something of the form [prog_name, args].
+    """
+    old_sys_argv = sys.argv
+    sys.argv = sys.argv[:1] + args
+    try:
+        yield
+    finally:
+        sys.argv = old_sys_argv

--- a/pcgrandom/test/write_pickle_data.py
+++ b/pcgrandom/test/write_pickle_data.py
@@ -1,3 +1,17 @@
+# Copyright 2017 Mark Dickinson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Tests that we can recover generators from pickles generated
 on different Python versions.
@@ -5,13 +19,48 @@ on different Python versions.
 import argparse
 import base64
 import json
+import os
 import pickle
+import pkgutil
 import platform
 
 from pcgrandom import pcg_generators
 
 
-def json_filenames():
+def bytes_to_string(b):
+    """Reversibly convert an arbitrary bytestring into a unicode string, for
+    JSON serialization.
+
+    """
+    return base64.b64encode(b).decode('ascii')
+
+
+def string_to_bytes(s):
+    """Reverse transformation for bytes_to_string.
+    """
+    return base64.b64decode(s.encode('ascii'))
+
+
+def list_to_tuple(l):
+    """Recursive list to tuple conversion."""
+    if isinstance(l, list):
+        return tuple(map(list_to_tuple, l))
+    else:
+        return l
+
+
+def test_data_directory():
+    """
+    Locate the test data directory.
+    """
+    test_package_name = 'pcgrandom.test'
+    test_package = pkgutil.get_loader(test_package_name).load_module(
+        test_package_name)
+    return os.path.join(
+        os.path.dirname(test_package.__file__), 'data')
+
+
+def pickle_filenames():
     """
     JSON filenames to write to, keyed by Python version.
 
@@ -19,9 +68,11 @@ def json_filenames():
     -------
     Mapping from Python version identifiers to output filenames.
     """
+    data_dir = test_data_directory()
+
     versions = ['python2', 'python3', 'pypy2', 'pypy3']
     return {
-        version: 'pickles-{}.json'.format(version)
+        version: os.path.join(data_dir, 'pickles-{}.json'.format(version))
         for version in versions
     }
 
@@ -43,12 +94,27 @@ def generators():
     ]
 
 
-def bytes_to_string(b):
-    """Reversibly convert an arbitrary bytestring into a unicode string, for
-    JSON serialization.
-
+def read_pickle_info(filename):
     """
-    return base64.b64encode(b).decode('ascii')
+    Read pickle data from a JSON file.
+
+    Returns
+    -------
+    pickle_data : dict
+        Nested dictionary containing pickle data.
+    """
+    with open(filename) as f:
+        all_pickle_data = json.load(f)
+
+    # Convert states back to tuples; decode the pickles.
+    for generator_data in all_pickle_data['generators']:
+        generator_data['state'] = list_to_tuple(generator_data['state'])
+
+        # Decode the pickles.
+        for pickle_data in generator_data['pickles']:
+            pickle_data['pickle'] = string_to_bytes(pickle_data['pickle'])
+
+    return all_pickle_data
 
 
 def write_pickle_info(generators, filename):

--- a/pcgrandom/test/write_pickle_data.py
+++ b/pcgrandom/test/write_pickle_data.py
@@ -1,0 +1,99 @@
+"""
+Tests that we can recover generators from pickles generated
+on different Python versions.
+"""
+import argparse
+import base64
+import json
+import pickle
+
+from pcgrandom import pcg_generators
+
+DEFAULT_OUTPUT = "pickles_python3.json"
+
+
+def available_protocols():
+    """
+    Available Pickle protocols for this version of Python.
+    """
+    return range(pickle.HIGHEST_PROTOCOL + 1)
+
+
+def generators():
+    return [
+        generator(seed=12345)
+        for generator in pcg_generators
+    ] + [
+        generator(seed=67189, sequence=34)
+        for generator in pcg_generators
+    ]
+
+
+def bytes_to_string(b):
+    """Reversibly convert an arbitrary bytestring into a unicode string, for
+    JSON serialization.
+
+    """
+    return base64.b64encode(b).decode('ascii')
+
+
+def write_pickle_info(generators, filename):
+    """
+    Write pickle information out in JSON form to the given filename.
+
+    The actual pickle bytestrings are base64 encoded, for ease of
+    JSON encoding.
+    """
+    generator_data = []
+    for generator in generators:
+        state = generator.getstate()
+
+        pickles = []
+        for protocol in available_protocols():
+            pickled_generator = pickle.dumps(generator, protocol=protocol)
+            pickles.append(
+                dict(
+                    protocol=protocol,
+                    pickle=bytes_to_string(pickled_generator),
+                )
+            )
+        generator_data.append(
+            dict(
+                state=state,
+                pickles=pickles,
+            )
+        )
+    file_content = {'generators': generator_data}
+
+    # XXX Refactor, so that the above logic isn't in the same
+    # place as the file writing.
+    with open(filename, 'w') as f:
+        json.dump(file_content, f, sort_keys=True, indent=4)
+        # json.dump doesn't write a trailing newline. Not a big
+        # deal, but for a line-based file it's nice to have one.
+        f.write("\n")
+
+
+def write_pickle_data():
+    """
+    Main script function for writing pickle data.
+    """
+    parser = argparse.ArgumentParser(
+        description="Regenerate pickle data.",
+    )
+    parser.add_argument(
+        "-o", "--output",
+        default=DEFAULT_OUTPUT,
+        help="Output path to write the data to (default: %(default)r).",
+    )
+
+    args = parser.parse_args()
+
+    write_pickle_info(
+        generators=generators(),
+        filename=args.output,
+    )
+
+
+if __name__ == '__main__':
+    write_pickle_data()

--- a/pcgrandom/test/write_pickle_data.py
+++ b/pcgrandom/test/write_pickle_data.py
@@ -6,6 +6,7 @@ import argparse
 import base64
 import json
 import pickle
+import platform
 
 from pcgrandom import pcg_generators
 
@@ -76,7 +77,20 @@ def write_pickle_info(generators, filename):
                 pickles=pickles,
             )
         )
-    file_content = {'generators': generator_data}
+
+    # Get platform information.
+    platform_info = {
+        'architecture': platform.architecture(),
+        'platform': platform.platform(),
+        'implementation': platform.python_implementation(),
+        'version': platform.python_version(),
+        'revision': platform.python_revision(),
+    }
+
+    file_content = dict(
+        generators=generator_data,
+        platform=platform_info,
+    )
 
     # XXX Refactor, so that the above logic isn't in the same
     # place as the file writing.

--- a/pcgrandom/test/write_pickle_data.py
+++ b/pcgrandom/test/write_pickle_data.py
@@ -12,6 +12,21 @@ from pcgrandom import pcg_generators
 DEFAULT_OUTPUT = "pickles_python3.json"
 
 
+def json_filenames():
+    """
+    JSON filenames to write to, keyed by Python version.
+
+    Returns
+    -------
+    Mapping from Python version identifiers to output filenames.
+    """
+    versions = ['python2', 'python3', 'pypy2', 'pypy3']
+    return {
+        version: 'pickles-{}.json'.format(version)
+        for version in versions
+    }
+
+
 def available_protocols():
     """
     Available Pickle protocols for this version of Python.

--- a/pcgrandom/test/write_pickle_data.py
+++ b/pcgrandom/test/write_pickle_data.py
@@ -9,8 +9,6 @@ import pickle
 
 from pcgrandom import pcg_generators
 
-DEFAULT_OUTPUT = "pickles_python3.json"
-
 
 def json_filenames():
     """
@@ -97,8 +95,7 @@ def write_pickle_data():
         description="Regenerate pickle data.",
     )
     parser.add_argument(
-        "-o", "--output",
-        default=DEFAULT_OUTPUT,
+        "output",
         help="Output path to write the data to (default: %(default)r).",
     )
 

--- a/scripts/write_pickles.py
+++ b/scripts/write_pickles.py
@@ -5,8 +5,10 @@ import os
 import pkgutil
 import subprocess
 
+from pcgrandom.test.write_pickle_data import json_filenames
+
 # Dictionary mapping python version id to executable paths on this system.
-PYTHON_VERSIONS = {
+EXECUTABLES = {
     'python2': 'python2',
     'python3': 'python',
     'pypy2': 'pypy',
@@ -30,9 +32,9 @@ def main():
     Regenerate pickle test data on a particular Python version.
     """
     data_dir = test_data_directory()
-    for version_id, python_executable in PYTHON_VERSIONS.items():
-        output_filename = os.path.join(
-            data_dir, 'pickles-{}.json'.format(version_id))
+    for version_id, json_filename in json_filenames().items():
+        python_executable = EXECUTABLES[version_id]
+        output_filename = os.path.join(data_dir, json_filename)
         cmd = [
             python_executable,
             '-m', 'pcgrandom.test.write_pickle_data',

--- a/scripts/write_pickles.py
+++ b/scripts/write_pickles.py
@@ -1,11 +1,23 @@
-"""
-Script used to regenerate test data.
-"""
-import os
-import pkgutil
-import subprocess
+# Copyright 2017 Mark Dickinson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from pcgrandom.test.write_pickle_data import json_filenames
+"""
+Script used to regenerate pickle test data.
+
+Requires that all relevant Python versions are present on this machine.
+"""
+import subprocess
 
 # Dictionary mapping python version id to executable paths on this system.
 EXECUTABLES = {
@@ -16,29 +28,18 @@ EXECUTABLES = {
 }
 
 
-def test_data_directory():
-    """
-    Locate the test data directory.
-    """
-    test_package_name = 'pcgrandom.test'
-    test_package = pkgutil.get_loader(test_package_name).load_module(
-        test_package_name)
-    return os.path.join(
-        os.path.dirname(test_package.__file__), 'data')
-
-
 def main():
     """
-    Regenerate pickle test data on a particular Python version.
+    Regenerate pickle test data for all Python versions.
     """
-    data_dir = test_data_directory()
-    for version_id, json_filename in json_filenames().items():
-        python_executable = EXECUTABLES[version_id]
-        output_filename = os.path.join(data_dir, json_filename)
+    from pcgrandom.test.write_pickle_data import pickle_filenames
+
+    for python_version, pickle_filename in pickle_filenames().items():
+        python_executable = EXECUTABLES[python_version]
         cmd = [
             python_executable,
             '-m', 'pcgrandom.test.write_pickle_data',
-            output_filename,
+            pickle_filename,
         ]
         subprocess.check_call(cmd)
 

--- a/scripts/write_pickles.py
+++ b/scripts/write_pickles.py
@@ -38,7 +38,7 @@ def main():
         cmd = [
             python_executable,
             '-m', 'pcgrandom.test.write_pickle_data',
-            '--output', output_filename,
+            output_filename,
         ]
         subprocess.check_call(cmd)
 

--- a/scripts/write_pickles.py
+++ b/scripts/write_pickles.py
@@ -1,0 +1,45 @@
+"""
+Script used to regenerate test data.
+"""
+import os
+import pkgutil
+import subprocess
+
+# Dictionary mapping python version id to executable paths on this system.
+PYTHON_VERSIONS = {
+    'python2': 'python2',
+    'python3': 'python',
+    'pypy2': 'pypy',
+    'pypy3': 'pypy3',
+}
+
+
+def test_data_directory():
+    """
+    Locate the test data directory.
+    """
+    test_package_name = 'pcgrandom.test'
+    test_package = pkgutil.get_loader(test_package_name).load_module(
+        test_package_name)
+    return os.path.join(
+        os.path.dirname(test_package.__file__), 'data')
+
+
+def main():
+    """
+    Regenerate pickle test data on a particular Python version.
+    """
+    data_dir = test_data_directory()
+    for version_id, python_executable in PYTHON_VERSIONS.items():
+        output_filename = os.path.join(
+            data_dir, 'pickles-{}.json'.format(version_id))
+        cmd = [
+            python_executable,
+            '-m', 'pcgrandom.test.write_pickle_data',
+            '--output', output_filename,
+        ]
+        subprocess.check_call(cmd)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR expands the pickle testing, and separates it from the rest of the reproducibility testing.

- Create JSON datafiles for pickle testing, one for each Python version that the pickles are generated on.
- Add utility script to refresh the JSON datafiles.
- Refactoring.