### PR TITLE
Simplify alpha=1.0 case of the gamma distribution

### DIFF
--- a/pcgrandom/distributions.py
+++ b/pcgrandom/distributions.py
@@ -197,10 +197,7 @@ class Distributions(object):
 
         elif alpha == 1.0:
             # expovariate(1/beta)
-            u = random()
-            while u <= 1e-7:
-                u = random()
-            return -log(u) * beta
+            return -log(1.0 - random()) * beta
 
         else:   # alpha is between 0 and 1 (exclusive)
 

--- a/pcgrandom/test/test_distributions.py
+++ b/pcgrandom/test/test_distributions.py
@@ -78,6 +78,10 @@ class TestDistributions(unittest.TestCase):
         sample = [self.gen.gammavariate(0.7, 1.3) for _ in range(10)]
         for elt in sample:
             self.assertIsInstance(elt, float)
+        # Generate enough deviates to exercise all the branches.
+        sample = [self.gen.gammavariate(0.2, 1.3) for _ in range(100)]
+        for elt in sample:
+            self.assertIsInstance(elt, float)
         sample = [self.gen.gammavariate(1.0, 1.3) for _ in range(10)]
         for elt in sample:
             self.assertIsInstance(elt, float)


### PR DESCRIPTION
Simplify the alpha=1.0 case to match the code in expovariate.

Also adds a bit more testing of the alpha < 1 case, to cover a previously non-covered line of code.

(See also http://bugs.python.org/issue30561.)