### PR TITLE
Unfeature: don't allow seeding from unicode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,11 +137,13 @@ There are some minor differences between the standard library ``Random`` class
 and the classes provided by ``pcgrandom``. Here we summarise the differences.
 
 - While the ``Random`` class permits seeding from an arbitrary hashable object,
-  the ``pcgrandom`` classes may only be seeded from integers and strings
-  (bytestrings or Unicode strings). Allowing arbitrary hashable objects makes
-  it harder to guarantee reproducibility in the event of Python's hashing
-  algorithms changing. See https://bugs.python.org/issue27706 for an example of
-  issues caused by this in the past.
+  the ``pcgrandom`` classes may only be seeded from integers and bytestrings
+  (or slighly more generally, any object supporting either ``__index__`` or the
+  buffer protocol). To hash from a Unicode string, encode it first. Allowing
+  arbitrary hashable objects makes it harder to guarantee reproducibility in
+  the event of Python's hashing algorithms changing. See
+  https://bugs.python.org/issue27706 for an example of issues caused by this in
+  the past.
 
 - The ``getrandbits`` method accepts an input of ``0``, returning ``0``
   (the unique integer in the range ``[0, 2**0)``). In ``random.Random``,

--- a/README.rst
+++ b/README.rst
@@ -139,7 +139,7 @@ and the classes provided by ``pcgrandom``. Here we summarise the differences.
 - While the ``Random`` class permits seeding from an arbitrary hashable object,
   the ``pcgrandom`` classes may only be seeded from integers and bytestrings
   (or slighly more generally, any object supporting either ``__index__`` or the
-  buffer protocol). To hash from a Unicode string, encode it first. Allowing
+  buffer protocol). To seed from a Unicode string, encode it first. Allowing
   arbitrary hashable objects makes it harder to guarantee reproducibility in
   the event of Python's hashing algorithms changing. See
   https://bugs.python.org/issue27706 for an example of issues caused by this in

--- a/pcgrandom/test/data/generator_fingerprints.json
+++ b/pcgrandom/test/data/generator_fingerprints.json
@@ -443,7 +443,7 @@
             ]
         },
         {
-            "constructor": "import pcgrandom\ngenerator = pcgrandom.PCG_XSH_RR_V0(seed=u\"noodleloaf\")\n",
+            "constructor": "import pcgrandom\ngenerator = pcgrandom.PCG_XSH_RR_V0(seed=u\"noodleloaf\".encode(\"utf-8\"))\n",
             "fingerprint": {
                 "bridge_hand": [
                     [
@@ -885,7 +885,7 @@
             ]
         },
         {
-            "constructor": "import pcgrandom\ngenerator = pcgrandom.PCG_XSH_RS_V0(seed=u\"\u03a4\u03bf \u03b1\u03b5\u03c1\u03bf\u03c3\u03c4\u03c1\u03c9\u03bc\u03b1\u03c4\u03cc\u03c7\u03b7\u03bc\u03ac \u03bc\u03bf\u03c5 \u03b5\u03af\u03bd\u03b1\u03b9 \u03b3\u03b5\u03bc\u03ac\u03c4\u03bf \u03c7\u03ad\u03bb\u03b9\u03b1\")\n",
+            "constructor": "import pcgrandom\ngenerator = pcgrandom.PCG_XSH_RS_V0(seed=u\"\u03a4\u03bf \u03b1\u03b5\u03c1\u03bf\u03c3\u03c4\u03c1\u03c9\u03bc\u03b1\u03c4\u03cc\u03c7\u03b7\u03bc\u03ac \u03bc\u03bf\u03c5 \u03b5\u03af\u03bd\u03b1\u03b9 \u03b3\u03b5\u03bc\u03ac\u03c4\u03bf \u03c7\u03ad\u03bb\u03b9\u03b1\".encode(\"utf-8\"))\n",
             "fingerprint": {
                 "bridge_hand": [
                     [

--- a/pcgrandom/test/regenerate_reproducibility_data.py
+++ b/pcgrandom/test/regenerate_reproducibility_data.py
@@ -36,16 +36,17 @@ def reproducibility_filename():
 
 # Generators used in reproducibility tests; short versions. Each
 # of these strings is expanded into something exec-able.
-_short_constructors = r"""
+_short_constructors = """\
 pcgrandom.PCG_XSH_RR_V0(seed=12345)
 pcgrandom.PCG_XSH_RR_V0(seed=12345, sequence=24)
-pcgrandom.PCG_XSH_RR_V0(seed=u"noodleloaf")
+pcgrandom.PCG_XSH_RR_V0(seed=u"noodleloaf".encode("utf-8"))
 pcgrandom.PCG_XSH_RS_V0(seed=90210, sequence=-7)
-pcgrandom.PCG_XSH_RS_V0(seed=u"Το αεροστρωματόχημά μου είναι γεμάτο χέλια")
+pcgrandom.PCG_XSH_RS_V0(seed=\
+    u"Το αεροστρωματόχημά μου είναι γεμάτο χέλια".encode("utf-8"))
 pcgrandom.PCG_XSL_RR_V0(seed=41509)
 pcgrandom.PCG_XSL_RR_V0(seed=-3, sequence=2**128 + 37)
-pcgrandom.PCG_XSL_RR_V0(seed=b"i am \x01 a byte \x00\xff string")
-"""[1:].splitlines()
+pcgrandom.PCG_XSL_RR_V0(seed=b"i am \\x01 a byte \\x00\\xff string")
+""".splitlines()
 
 
 def constructors():

--- a/pcgrandom/test/test_pcg_common.py
+++ b/pcgrandom/test/test_pcg_common.py
@@ -47,8 +47,8 @@ class TestSeedingFunctions(unittest.TestCase):
 
     def test_seed_from_object_large_bits(self):
         with self.assertRaises(ValueError):
-            seed_from_object("some string or other", 513)
-        seed = seed_from_object("some string or other", 512)
+            seed_from_object(b"some string or other", 513)
+        seed = seed_from_object(b"some string or other", 512)
         self.assertGreater(seed.bit_length(), 500)
         self.assertLessEqual(seed.bit_length(), 512)
 
@@ -88,9 +88,9 @@ class TestPCGCommon(object):
         self.assertEqual(gen1.getstate(), gen2.getstate())
         self.assertEqual(gen1.getstate(), gen3.getstate())
 
-    def test_seed_from_bytes_and_unicode(self):
+    def test_seed_from_buffer(self):
         gen1 = self.gen_class(seed=b"your mother was a hamster")
-        gen2 = self.gen_class(seed=u"your mother was a hamster")
+        gen2 = self.gen_class(seed=bytearray(b"your mother was a hamster"))
         self.assertEqual(gen1.getstate(), gen2.getstate())
 
     def test_sequence_default(self):


### PR DESCRIPTION
Allowing seeding from Unicode is fraught with potential issues (normalization, surrogate pairs). We disallow it for now.

This PR also modifies the seeding from object to allow anything that can be used in `hashlib.sha512`, which amounts to anything that supports the buffer protocol.