### PR TITLE
Fix trailing spaces in JSON files.

### DIFF
--- a/pcgrandom/test/data/pickles-pypy2.json
+++ b/pcgrandom/test/data/pickles-pypy2.json
@@ -3,162 +3,162 @@
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cDYKTnRwNwpiLg==", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cDYKTnRwNwpiLg==",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cQZOdHEHYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cQZOdHEHYi4=",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQpJMTQ0MjY5NTA0MDg4ODk2MzQwNwqKCDcu3JmDyhAih3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQpJMTQ0MjY5NTA0MDg4ODk2MzQwNwqKCDcu3JmDyhAih3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSH_RR_V0", 
+                "pcgrandom.PCG_XSH_RR_V0",
                 [
-                    6364136223846793005, 
-                    1442695040888963407, 
+                    6364136223846793005,
+                    1442695040888963407,
                     2454684463487790647
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cDYKTnRwNwpiLg==", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cDYKTnRwNwpiLg==",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cQZOdHEHYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cQZOdHEHYi4=",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQpJMTQ0MjY5NTA0MDg4ODk2MzQwNwqKCDcu3JmDyhAih3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQpJMTQ0MjY5NTA0MDg4ODk2MzQwNwqKCDcu3JmDyhAih3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSH_RS_V0", 
+                "pcgrandom.PCG_XSH_RS_V0",
                 [
-                    6364136223846793005, 
-                    1442695040888963407, 
+                    6364136223846793005,
+                    1442695040888963407,
                     2454684463487790647
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKdHA2Ck50cDcKYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKdHA2Ck50cDcKYi4=",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKdHEGTnRxB2Iu", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKdHEGTnRxB2Iu",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwcQKKEEX2zJ9k34VDpF3GHwXtYCOKEE+BZ/d+ewUULX+VTC30UViKEPcKUzt6JdHONBr83eJ6d1WHcQNOh3EEYi4=", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwcQKKEEX2zJ9k34VDpF3GHwXtYCOKEE+BZ/d+ewUULX+VTC30UViKEPcKUzt6JdHONBr83eJ6d1WHcQNOh3EEYi4=",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSL_RR_V0", 
+                "pcgrandom.PCG_XSL_RR_V0",
                 [
-                    47026247687942121848144207491837523525, 
-                    117397592171526113268558934119004209487, 
+                    47026247687942121848144207491837523525,
+                    117397592171526113268558934119004209487,
                     113604755396120827644872873925328177911
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHA2Ck50cDcKYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHA2Ck50cDcKYi4=",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHEGTnRxB2Iu", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHEGTnRxB2Iu",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQqKAUWKCPd0xqRKxXELh3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQqKAUWKCPd0xqRKxXELh3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSH_RR_V0", 
+                "pcgrandom.PCG_XSH_RR_V0",
                 [
-                    6364136223846793005, 
-                    69, 
+                    6364136223846793005,
+                    69,
                     824657131168232695
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHA2Ck50cDcKYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHA2Ck50cDcKYi4=",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHEGTnRxB2Iu", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHEGTnRxB2Iu",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQqKAUWKCPd0xqRKxXELh3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQqKAUWKCPd0xqRKxXELh3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSH_RS_V0", 
+                "pcgrandom.PCG_XSH_RS_V0",
                 [
-                    6364136223846793005, 
-                    69, 
+                    6364136223846793005,
+                    69,
                     824657131168232695
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TApMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TAp0cDYKTnRwNwpiLg==", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TApMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TAp0cDYKTnRwNwpiLg==",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TApMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TAp0cQZOdHEHYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TApMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TAp0cQZOdHEHYi4=",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwcQKKEEX2zJ9k34VDpF3GHwXtYCOKAUWKEWeM9d6nSuURdCb2GT50/+YAh3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwcQKKEEX2zJ9k34VDpF3GHwXtYCOKAUWKEWeM9d6nSuURdCb2GT50/+YAh3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSL_RR_V0", 
+                "pcgrandom.PCG_XSL_RR_V0",
                 [
-                    47026247687942121848144207491837523525, 
-                    69, 
+                    47026247687942121848144207491837523525,
+                    69,
                     307048832409151833879506015154399972455
-                ], 
+                ],
                 null
             ]
         }
-    ], 
+    ],
     "platform": {
         "architecture": [
-            "64bit", 
+            "64bit",
             ""
-        ], 
-        "implementation": "PyPy", 
-        "platform": "Darwin-14.5.0-x86_64-i386-64bit", 
-        "revision": "", 
+        ],
+        "implementation": "PyPy",
+        "platform": "Darwin-14.5.0-x86_64-i386-64bit",
+        "revision": "",
         "version": "2.7.13"
     }
 }

--- a/pcgrandom/test/data/pickles-python2.json
+++ b/pcgrandom/test/data/pickles-python2.json
@@ -3,162 +3,162 @@
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cDYKTnRwNwpiLg==", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cDYKTnRwNwpiLg==",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cQZOdHEHYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cQZOdHEHYi4=",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQpJMTQ0MjY5NTA0MDg4ODk2MzQwNwqKCDcu3JmDyhAih3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQpJMTQ0MjY5NTA0MDg4ODk2MzQwNwqKCDcu3JmDyhAih3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSH_RR_V0", 
+                "pcgrandom.PCG_XSH_RR_V0",
                 [
-                    6364136223846793005, 
-                    1442695040888963407, 
+                    6364136223846793005,
+                    1442695040888963407,
                     2454684463487790647
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cDYKTnRwNwpiLg==", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cDYKTnRwNwpiLg==",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cQZOdHEHYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1CkkxNDQyNjk1MDQwODg4OTYzNDA3CkwyNDU0Njg0NDYzNDg3NzkwNjQ3TAp0cQZOdHEHYi4=",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQpJMTQ0MjY5NTA0MDg4ODk2MzQwNwqKCDcu3JmDyhAih3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQpJMTQ0MjY5NTA0MDg4ODk2MzQwNwqKCDcu3JmDyhAih3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSH_RS_V0", 
+                "pcgrandom.PCG_XSH_RS_V0",
                 [
-                    6364136223846793005, 
-                    1442695040888963407, 
+                    6364136223846793005,
+                    1442695040888963407,
                     2454684463487790647
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKdHA2Ck50cDcKYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKdHA2Ck50cDcKYi4=",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKdHEGTnRxB2Iu", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDExNzM5NzU5MjE3MTUyNjExMzI2ODU1ODkzNDExOTAwNDIwOTQ4N0wKTDExMzYwNDc1NTM5NjEyMDgyNzY0NDg3Mjg3MzkyNTMyODE3NzkxMUwKdHEGTnRxB2Iu",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwcQKKEEX2zJ9k34VDpF3GHwXtYCOKEE+BZ/d+ewUULX+VTC30UViKEPcKUzt6JdHONBr83eJ6d1WHcQNOh3EEYi4=", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwcQKKEEX2zJ9k34VDpF3GHwXtYCOKEE+BZ/d+ewUULX+VTC30UViKEPcKUzt6JdHONBr83eJ6d1WHcQNOh3EEYi4=",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSL_RR_V0", 
+                "pcgrandom.PCG_XSL_RR_V0",
                 [
-                    47026247687942121848144207491837523525, 
-                    117397592171526113268558934119004209487, 
+                    47026247687942121848144207491837523525,
+                    117397592171526113268558934119004209487,
                     113604755396120827644872873925328177911
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHA2Ck50cDcKYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlJfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHA2Ck50cDcKYi4=",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHEGTnRxB2Iu", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9ycl92MApQQ0dfWFNIX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SUl9WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHEGTnRxB2Iu",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQqKAUWKCPd0xqRKxXELh3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnJfdjAKUENHX1hTSF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JSX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQqKAUWKCPd0xqRKxXELh3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSH_RR_V0", 
+                "pcgrandom.PCG_XSH_RR_V0",
                 [
-                    6364136223846793005, 
-                    69, 
+                    6364136223846793005,
+                    69,
                     824657131168232695
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHA2Ck50cDcKYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0hfUlNfVjAKcDUKKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHA2Ck50cDcKYi4=",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHEGTnRxB2Iu", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzaF9yc192MApQQ0dfWFNIX1JTX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTSF9SU19WMHEFKEk2MzY0MTM2MjIzODQ2NzkzMDA1Ckw2OUwKTDgyNDY1NzEzMTE2ODIzMjY5NUwKdHEGTnRxB2Iu",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQqKAUWKCPd0xqRKxXELh3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2hfcnNfdjAKUENHX1hTSF9SU19WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNIX1JTX1YwcQJJNjM2NDEzNjIyMzg0Njc5MzAwNQqKAUWKCPd0xqRKxXELh3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSH_RS_V0", 
+                "pcgrandom.PCG_XSH_RS_V0",
                 [
-                    6364136223846793005, 
-                    69, 
+                    6364136223846793005,
+                    69,
                     824657131168232695
-                ], 
+                ],
                 null
             ]
-        }, 
+        },
         {
             "pickles": [
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TApMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TAp0cDYKTnRwNwpiLg==", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApwMQpjX19idWlsdGluX18Kb2JqZWN0CnAyCk50cDMKUnA0CihWcGNncmFuZG9tLlBDR19YU0xfUlJfVjAKcDUKKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TApMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TAp0cDYKTnRwNwpiLg==",
                     "protocol": 0
-                }, 
+                },
                 {
-                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TApMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TAp0cQZOdHEHYi4=", 
+                    "pickle": "Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnEAKGNwY2dyYW5kb20ucGNnX3hzbF9ycl92MApQQ0dfWFNMX1JSX1YwCnEBY19fYnVpbHRpbl9fCm9iamVjdApxAk50cQNScQQoWBcAAABwY2dyYW5kb20uUENHX1hTTF9SUl9WMHEFKEw0NzAyNjI0NzY4Nzk0MjEyMTg0ODE0NDIwNzQ5MTgzNzUyMzUyNUwKTDY5TApMMzA3MDQ4ODMyNDA5MTUxODMzODc5NTA2MDE1MTU0Mzk5OTcyNDU1TAp0cQZOdHEHYi4=",
                     "protocol": 1
-                }, 
+                },
                 {
-                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwcQKKEEX2zJ9k34VDpF3GHwXtYCOKAUWKEWeM9d6nSuURdCb2GT50/+YAh3EDTodxBGIu", 
+                    "pickle": "gAJjcGNncmFuZG9tLnBjZ194c2xfcnJfdjAKUENHX1hTTF9SUl9WMApxACmBcQFYFwAAAHBjZ3JhbmRvbS5QQ0dfWFNMX1JSX1YwcQKKEEX2zJ9k34VDpF3GHwXtYCOKAUWKEWeM9d6nSuURdCb2GT50/+YAh3EDTodxBGIu",
                     "protocol": 2
                 }
-            ], 
+            ],
             "state": [
-                "pcgrandom.PCG_XSL_RR_V0", 
+                "pcgrandom.PCG_XSL_RR_V0",
                 [
-                    47026247687942121848144207491837523525, 
-                    69, 
+                    47026247687942121848144207491837523525,
+                    69,
                     307048832409151833879506015154399972455
-                ], 
+                ],
                 null
             ]
         }
-    ], 
+    ],
     "platform": {
         "architecture": [
-            "64bit", 
+            "64bit",
             ""
-        ], 
-        "implementation": "CPython", 
-        "platform": "Darwin-14.5.0-x86_64-i386-64bit", 
-        "revision": "", 
+        ],
+        "implementation": "CPython",
+        "platform": "Darwin-14.5.0-x86_64-i386-64bit",
+        "revision": "",
         "version": "2.7.14"
     }
 }

--- a/pcgrandom/test/fingerprint.py
+++ b/pcgrandom/test/fingerprint.py
@@ -137,7 +137,10 @@ def write_fingerprints(constructors, filename):
         ],
     }
     with open(filename, 'w') as f:
-        json.dump(file_content, f, sort_keys=True, indent=4)
+        json.dump(
+            file_content, f, sort_keys=True, indent=4,
+            separators=(',', ': '),
+        )
         # json.dump doesn't write a trailing newline. Not a big
         # deal, but for a line-based file it's nice to have one.
         f.write("\n")

--- a/pcgrandom/test/write_pickle_data.py
+++ b/pcgrandom/test/write_pickle_data.py
@@ -154,7 +154,10 @@ class AllGeneratorsPickles(object):
             platform=self.platform_info,
         )
         with open(filename, 'w') as f:
-            json.dump(file_content, f, sort_keys=True, indent=4)
+            json.dump(
+                file_content, f, sort_keys=True, indent=4,
+                separators=(',', ': '),
+            )
             # json.dump doesn't write a trailing newline. Not a big
             # deal, but for a line-based file it's nice to have one.
             f.write("\n")


### PR DESCRIPTION
Fixing a minor annoyance: Python 2 uses a default item separator of `", "`, while Python 3 uses a default item separator of `","`. Specify the separators directly for consistency.