### PR TITLE
Add coverage-related files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+.coverage
+htmlcov


### PR DESCRIPTION
To ensure we don't accidentally commit the coverage results.